### PR TITLE
WIP: 尝试修复旧版模型的extra动画解析问题

### DIFF
--- a/common/src/main/java/com/micaftic/morpher/resource/YSMFolderDeserializer.java
+++ b/common/src/main/java/com/micaftic/morpher/resource/YSMFolderDeserializer.java
@@ -1273,6 +1273,9 @@ public class YSMFolderDeserializer implements AutoCloseable {
                 String animKey = fileName.substring(0, fileName.length() - ".animation.json".length());
                 raf.animType = getAnimTypeFromKey(animKey);
                 model.mainEntity.animationFiles.put(animKey, raf);
+                if("extra".equals(animKey)) {
+                    raf.animations.keySet().forEach(animName -> model.properties.extraAnimations.put(animName, animName));
+                }
             }
         }
 


### PR DESCRIPTION
GI_Hutao模型中包含extra.animation.json, 但实际上给Z (打开轮盘页面快捷键) 打断点发现: `model.properties.extraAnimations` 是空白的
在跟进ClientModelManger.parseYsmImport()方法后进入了YSMFolderDeserializer中, 在YSMFolderDeserializer.java的L1275处, 似乎未对model.properties.extraAnimations加入动画, 导致轮盘为空白打不开
model.properties.extraAnimations传入的值未确定, 所以要进一步进行测试. (代码提交后能正常打开轮盘页面, 但是无法播放动画)