### PR TITLE
feat(1.2.4): 模型选择改为 Faithful 3D 卡片目录(实时3D预览卡片)

### DIFF
--- a/common/src/main/java/com/micaftic/morpher/client/gui/ModelPanelLayout.java
+++ b/common/src/main/java/com/micaftic/morpher/client/gui/ModelPanelLayout.java
@@ -42,14 +42,15 @@ final class ModelPanelLayout {
     }
 
     static ModelPanelLayout create(int screenWidth, int screenHeight) {
-        int marginX = screenWidth >= 760 ? 32 : 12;
-        int marginY = screenHeight >= 420 ? 28 : 12;
-        int maxWidth = Math.max(1, screenWidth - marginX);
-        int maxHeight = Math.max(1, screenHeight - marginY);
-        int panelWidth = clamp(screenWidth - marginX, Math.min(520, maxWidth), Math.min(920, maxWidth));
-        int panelHeight = clamp(screenHeight - marginY, Math.min(300, maxHeight), Math.min(540, maxHeight));
-        double guiScale = net.minecraft.client.Minecraft.getInstance().getWindow().getGuiScale();
-        boolean verticalTabs = guiScale >= 3.0 || screenHeight < 300 || screenWidth < 430;
+        // 面板随逻辑分辨率按比例放大:大屏留比例边距,小屏几乎全屏;硬顶去掉后超大屏能装更多内容。
+        int marginX = screenWidth >= 760 ? clamp(screenWidth / 24, 28, 80) : 12;
+        int marginY = screenHeight >= 460 ? clamp(screenHeight / 24, 24, 60) : 12;
+        int availW = Math.max(1, screenWidth - marginX);
+        int availH = Math.max(1, screenHeight - marginY);
+        int panelWidth = clamp(availW, Math.min(520, availW), Math.min(1600, availW));
+        int panelHeight = clamp(availH, Math.min(300, availH), Math.min(900, availH));
+        // 竖向选项卡只看逻辑宽高:极窄/极矮才竖排。guiScale 是物理/逻辑比值,与逻辑空间无关,不再参与。
+        boolean verticalTabs = screenHeight < 300 || screenWidth < 430;
         boolean tight = verticalTabs || screenHeight < 400 || screenWidth < 560;
         return new ModelPanelLayout((screenWidth - panelWidth) / 2, (screenHeight - panelHeight) / 2, panelWidth, panelHeight, tight, verticalTabs);
     }

--- a/common/src/main/java/com/micaftic/morpher/client/gui/ModelPanelState.java
+++ b/common/src/main/java/com/micaftic/morpher/client/gui/ModelPanelState.java
@@ -50,7 +50,7 @@ final class ModelPanelState {
     int settingsScroll;
     int sitesScroll;
     int categoryScroll;
-    boolean compactPreviewExpanded;
+    int compactPreviewState; // 底部紧凑详情条:0=auto(选中即展开),1=展开,2=收起
     boolean resourceLoaded;
     boolean resourceLoading;
     int resourceRequestId;

--- a/common/src/main/java/com/micaftic/morpher/client/renderer/ModelPreviewRenderer.java
+++ b/common/src/main/java/com/micaftic/morpher/client/renderer/ModelPreviewRenderer.java
@@ -199,6 +199,10 @@ public final class ModelPreviewRenderer {
     }
 
     public static <T extends LivingEntity, TAnimatable extends LivingAnimatable<T>> void renderLivingEntityPreview(GuiGraphicsExtractor guiGraphics, int left, int top, int right, int bottom, float originX, float originY, float scale, float partialTick, TAnimatable animatable, GeoReplacedEntityRenderer<T, TAnimatable> renderer, boolean disablePreviewRotation, boolean hideEquipment, int mouseX, int mouseY) {
+        renderLivingEntityPreview(guiGraphics, left, top, right, bottom, originX, originY, scale, partialTick, animatable, renderer, disablePreviewRotation, hideEquipment, mouseX, mouseY, 0.0f, 0.0f);
+    }
+
+    public static <T extends LivingEntity, TAnimatable extends LivingAnimatable<T>> void renderLivingEntityPreview(GuiGraphicsExtractor guiGraphics, int left, int top, int right, int bottom, float originX, float originY, float scale, float partialTick, TAnimatable animatable, GeoReplacedEntityRenderer<T, TAnimatable> renderer, boolean disablePreviewRotation, boolean hideEquipment, int mouseX, int mouseY, float extraYaw, float extraPitch) {
         if (guiGraphics == null || animatable == null || renderer == null || right <= left || bottom <= top) {
             return;
         }
@@ -212,8 +216,8 @@ public final class ModelPreviewRenderer {
                 renderer,
                 disablePreviewRotation,
                 hideEquipment,
-                (disablePreviewRotation ? 180.0f : 200.0f) + mouseRotation.yaw,
-                mouseRotation.pitch,
+                (disablePreviewRotation ? 180.0f : 200.0f) + mouseRotation.yaw + extraYaw,
+                mouseRotation.pitch + extraPitch,
                 false
         ));
         guiGraphics.entity(state, scale, new Vector3f(), new Quaternionf(), null, left, top, right, bottom);

--- a/common/src/main/java/com/micaftic/morpher/resource/YSMFolderDeserializer.java
+++ b/common/src/main/java/com/micaftic/morpher/resource/YSMFolderDeserializer.java
@@ -257,21 +257,31 @@ public class YSMFolderDeserializer implements AutoCloseable {
     }
 
     private void loadGuiImage(String path, String id) {
-        if (path == null || path.isEmpty()) return;
-        byte[] data = readResource(path);
-        if (data == null) data = readResource("background/" + id + ".png");
-
-        if (data != null) {
-            ImageMeta meta = parseImageMeta(data, path);
-            RawYsmModel.RawImage img = new RawYsmModel.RawImage();
-            img.width = meta.width();
-            img.height = meta.height();
-            img.format = meta.format();
-            img.name = id;
-            img.data = data;
-            img.unknownFlag = 1;
-            model.properties.backgroundImages.add(img);
+        byte[] data = null;
+        if (path != null && !path.isEmpty()) {
+            data = readResource(path);
         }
+        if (data == null) {
+            data = readResource(id + ".png");
+        }
+        if (data == null) {
+            data = readResource(id + ".jpg");
+        }
+        if (data == null) {
+            data = readResource("background/" + id + ".png");
+        }
+        if (data == null) {
+            return;
+        }
+        ImageMeta meta = parseImageMeta(data, path == null || path.isEmpty() ? id : path);
+        RawYsmModel.RawImage img = new RawYsmModel.RawImage();
+        img.width = meta.width();
+        img.height = meta.height();
+        img.format = meta.format();
+        img.name = id;
+        img.data = data;
+        img.unknownFlag = 1;
+        model.properties.backgroundImages.add(img);
     }
 
     private void parseMainEntity(JsonObject playerObj) {

--- a/fabric/src/main/java/com/micaftic/morpher/client/gui/ModernPlayerModelScreen.java
+++ b/fabric/src/main/java/com/micaftic/morpher/client/gui/ModernPlayerModelScreen.java
@@ -13,6 +13,7 @@ import com.micaftic.morpher.client.gui.resource.ModelRepoEntry;
 import com.micaftic.morpher.client.gui.resource.ResourceDownloadManager;
 import com.micaftic.morpher.client.gui.resource.ResourceStationConfig;
 import com.micaftic.morpher.client.gui.metadata.ModelDisplayAssets;
+import com.micaftic.morpher.resource.models.ModelPackData;
 import com.micaftic.morpher.client.model.ModelAssembly;
 import com.micaftic.morpher.client.renderer.ModelPreviewRenderer;
 import com.micaftic.morpher.client.renderer.RendererManager;
@@ -83,6 +84,7 @@ import java.util.function.BiConsumer;
 public class ModernPlayerModelScreen extends Screen {
     private static final ModelPanelState STATE = new ModelPanelState();
     private static final Identifier MODEL_PANEL_ICONS = com.micaftic.morpher.core.api.resource.ResourceApi.nativeId(YesSteveModel.MOD_ID, "texture/model_panel_icons.png");
+    private static final Identifier DEFAULT_PACK_ICON = com.micaftic.morpher.core.api.resource.ResourceApi.nativeId(YesSteveModel.MOD_ID, "texture/default_pack_icon.png");
     private static final int BG = 0x90171A1D;
     private static final int PANEL = 0x4A34424A;
     private static final int PANEL_HOVER = 0x66576B76;
@@ -125,7 +127,7 @@ public class ModernPlayerModelScreen extends Screen {
     private static final int CAT_MIN_W = 140;              // 进入卡片页的最小网格宽
     private static final int CAT_MIN_H = 120;              // 进入卡片页的最小网格高
     private static final float CAT_ASPECT = 1.73f;         // 竖卡比例 52:90
-    private static final int PRELOAD_BUDGET = 4;         // 每 tick 最多新启动的预载数
+    private static final int PRELOAD_BUDGET = 16;
     private static final int PRELOAD_GIVE_UP_TICKS = 400; // 预载观察超时(约20秒),超时未落地判为失败
     private static final int WHEEL_STEP_MAX = 28;        // 模型网格单次滚轮的像素步长上限
     /** 封面尺寸缓存:gui 封面 texture 实例 -> [宽,高]。键是弱引用,随 assembly 一起回收。 */
@@ -141,6 +143,13 @@ public class ModernPlayerModelScreen extends Screen {
     /** 目录卡片页:每卡一个实时 3D 预览实体(按 modelId 缓存,仅保留当页 ≤10)。 */
     private final Map<String, PlayerPreviewEntity> cardPreviewEntities = new LinkedHashMap<>(16);
     private final Map<String, String> cardPreviewTextureIds = new LinkedHashMap<>(16);
+    private final YsmCardAnimator cardAnimator = new YsmCardAnimator();
+    private static final float layoutGridX = 78f;
+    private static final float layoutGridY = -16f;
+    private static final float layoutBandY = 28f;
+    private static final float layoutRefX = -27f;
+    private static final float layoutRefY = 9f;
+    private static final float layoutHdrY = -1f;
     private final Screen parentScreen;
     private final BiConsumer<String, String> modelSelectionTarget;
     private ModelPanelLayout layout;
@@ -267,7 +276,7 @@ public class ModernPlayerModelScreen extends Screen {
         this.siteEditBox = null;
         this.categoryEditBox = null;
         if (STATE.activeTab == ModelPanelState.Tab.MODEL) {
-            this.modelSearchBox = new EditBox(this.font, modelListX(), this.layout.contentTop + 8, modelListW(), 16, Component.translatable("gui.sparkle_morpher.resource_station.search"));
+            this.modelSearchBox = new EditBox(this.font, ysmPaneX(), ysmPaneY() + (int) layoutHdrY, 150, 16, Component.translatable("gui.sparkle_morpher.resource_station.search"));
             this.modelSearchBox.setMaxLength(256);
             this.modelSearchBox.setValue(STATE.modelSearchText);
             this.modelSearchBox.setTextColor(TEXT);
@@ -380,7 +389,7 @@ public class ModernPlayerModelScreen extends Screen {
         blurGlass(g, this.layout.contentLeft, this.layout.contentTop, this.layout.contentWidth, this.layout.contentHeight, 0x1CFFFFFF, 6.0f);
         fill(g, this.layout.contentLeft, this.layout.contentTop, this.layout.contentWidth, this.layout.contentHeight, 0x18171A1D);
         switch (STATE.activeTab) {
-            case MODEL -> renderModelTab(g, mainMouseX, mainMouseY, partialTick);
+            case MODEL -> renderYsmModelTab(g, mainMouseX, mainMouseY, partialTick);
             case RESOURCE -> renderResourceTab(g, mainMouseX, mainMouseY, partialTick);
             case SETTINGS -> renderSettingsTab(g, mainMouseX, mainMouseY);
         }
@@ -603,6 +612,206 @@ public class ModernPlayerModelScreen extends Screen {
         }
     }
 
+    private static final int YSM_CARD_W = 52;
+    private static final int YSM_CARD_H = 90;
+    private static final int YSM_COL_PITCH = 55;
+    private static final int YSM_ROW_PITCH = 93;
+    private static final int YSM_GRID_TOP = 44;
+    private static final int YSM_PAGE_BAND = 34;
+    private static final float[][] YSM_CAM = {
+            {31.1f, 0.9f, 0.5f, -0.7f},
+            {32.5f, 4.4f, -0.3f, 0.0f}
+    };
+
+    private boolean ysmDialogMode() {
+        return this.layout.contentWidth >= 660 && this.layout.contentHeight >= 400;
+    }
+
+    private int ysmDialogW() {
+        return Math.min(this.layout.contentWidth - 48, 640);
+    }
+
+    private int ysmDialogH() {
+        return Math.min(this.layout.contentHeight - 72, 560);
+    }
+
+    private int ysmPaneX() {
+        if (ysmDialogMode()) {
+            return this.layout.contentLeft + (this.layout.contentWidth - ysmDialogW()) / 2 + 10;
+        }
+        return this.layout.contentLeft + 4;
+    }
+
+    private int ysmPaneY() {
+        if (ysmDialogMode()) {
+            return this.layout.contentTop + (this.layout.contentHeight - ysmDialogH()) / 2 + 8;
+        }
+        return this.layout.contentTop + 6;
+    }
+
+    private int ysmRight() {
+        if (ysmDialogMode()) {
+            return ysmPaneX() + ysmDialogW() - 20;
+        }
+        return this.layout.contentLeft + this.layout.contentWidth - 4;
+    }
+
+    private int ysmBottom() {
+        if (ysmDialogMode()) {
+            return ysmPaneY() + ysmDialogH() - 12;
+        }
+        return this.layout.footerTop - 6;
+    }
+
+    private List<ModelEntry> modelYsmEntries() {
+        List<ModelEntry> all = new ArrayList<>(collectModelEntries());
+        if (STATE.modelFilter == ModelPanelState.ModelFilter.STAR) {
+            all.removeIf(entry -> !entry.folder() && !starModels().contains(entry.modelId()));
+        }
+        return all;
+    }
+
+    private int[] ysmGridMetrics() {
+        return new int[]{5, 2, 10};
+    }
+
+    private void renderYsmModelTab(GuiGraphicsExtractor g, int mouseX, int mouseY, float partialTick) {
+        int px = ysmPaneX();
+        int py = ysmPaneY();
+        if (ysmDialogMode()) {
+            fill(g, this.layout.contentLeft, this.layout.contentTop, this.layout.contentWidth, this.layout.contentHeight, 0x66000000);
+            fill(g, px - 10, py - 8, ysmDialogW(), ysmDialogH(), 0xFF1E2126);
+            border(g, px - 10, py - 8, ysmDialogW(), ysmDialogH(), 0x88FFFFFF);
+        }
+        int headerY = py + (int) layoutHdrY;
+        int right = ysmRight();
+        int contentBottom = ysmBottom();
+
+        int toolX = right - 3 * 18 - 6;
+        renderIconButton(g, mouseX, mouseY, toolX, headerY, IconGlyph.FOLDER,
+                Component.translatable("gui.sparkle_morpher.open_model_folder.open"), this::openModelFolder);
+        renderIconButton(g, mouseX, mouseY, toolX + 20, headerY, IconGlyph.RESOURCE,
+                Component.translatable("gui.sparkle_morpher.resource_station.title"), () -> switchTab(ModelPanelState.Tab.RESOURCE));
+        renderIconButton(g, mouseX, mouseY, toolX + 40, headerY, IconGlyph.SETTINGS,
+                Component.translatable("gui.sparkle_morpher.model_panel.settings"), () -> switchTab(ModelPanelState.Tab.SETTINGS));
+        int filterX = toolX - 3 * 18 - 8;
+        renderYsmFilterIcon(g, mouseX, mouseY, filterX, headerY, ModelPanelState.ModelFilter.STAR, IconGlyph.STAR,
+                Component.translatable("gui.sparkle_morpher.model_panel.filter.star"));
+        renderYsmFilterIcon(g, mouseX, mouseY, filterX + 20, headerY, ModelPanelState.ModelFilter.AUTH, IconGlyph.LOCK,
+                Component.translatable("gui.sparkle_morpher.model_panel.filter.auth"));
+        renderYsmFilterIcon(g, mouseX, mouseY, filterX + 40, headerY, ModelPanelState.ModelFilter.ALL, IconGlyph.ROOT,
+                Component.translatable("gui.sparkle_morpher.model_panel.filter.all"));
+        if (this.modelSearchBox != null) {
+            this.modelSearchBox.extractWidgetRenderState(g, mouseX, mouseY, partialTick);
+            if (this.modelSearchBox.getValue().isEmpty() && !this.modelSearchBox.isFocused()) {
+                g.text(this.font, Component.translatable("gui.sparkle_morpher.resource_station.search"),
+                        px + 4, headerY + 4, 0x777777, false);
+            }
+        }
+        if (!STATE.currentPath.isBlank()) {
+            renderIconButton(g, mouseX, mouseY, px + 158, headerY, IconGlyph.UP,
+                    Component.translatable("gui.back"), this::navigateUp);
+        }
+
+        int cols = 5;
+        int rows = 2;
+        int perPage = cols * rows;
+        int gridW = cols * YSM_COL_PITCH - 3;
+        int gx = px + Math.max(0, (right - px - gridW) / 2) + (int) layoutGridX;
+        int gridTop = py + YSM_GRID_TOP + (int) layoutGridY;
+        int pvW = 124;
+        int pvH = 168;
+        int refX = Math.max(px, gx - pvW - 8) + (int) layoutRefX;
+        int refY = gridTop + (int) layoutRefY;
+        renderYsmPreviewPane(g, mouseX, mouseY, refX, refY, pvW, pvH, partialTick);
+        List<ModelEntry> entries = modelYsmEntries();
+        int pages = Math.max(1, (entries.size() + perPage - 1) / perPage);
+        int page = clamp(STATE.modelScroll, 0, pages - 1);
+        STATE.modelScroll = page;
+        int start = page * perPage;
+        Set<String> starred = starModels();
+        for (int slot = 0; slot < perPage; slot++) {
+            int index = start + slot;
+            if (index >= entries.size()) {
+                break;
+            }
+            int cx = gx + YSM_COL_PITCH * (slot % cols);
+            int cy = gridTop + YSM_ROW_PITCH * (slot / cols);
+            renderCatalogCard(g, mouseX, mouseY, entries.get(index), cx, cy, YSM_CARD_W, YSM_CARD_H, starred, partialTick);
+        }
+
+        int bandY = contentBottom - 22 + (int) layoutBandY;
+        int centerX = gx + gridW / 2;
+        renderTextButton(g, mouseX, mouseY, centerX - 70, bandY, 52, 14, Component.literal("‹"), () -> {
+            if (page > 0) {
+                STATE.modelScroll = page - 1;
+            }
+        });
+        renderTextButton(g, mouseX, mouseY, centerX + 18, bandY, 52, 14, Component.literal("›"), () -> {
+            if (page < pages - 1) {
+                STATE.modelScroll = page + 1;
+            }
+        });
+        Component pageLabel = Component.literal((page + 1) + "/" + pages);
+        g.text(this.font, pageLabel, centerX - this.font.width(pageLabel) / 2, bandY + 2, CAT_NAME, false);
+    }
+
+    private void renderYsmPreviewPane(GuiGraphicsExtractor g, int mouseX, int mouseY, int x, int y, int w, int h, float partialTick) {
+        fill(g, x, y, w, h, 0xDF1A1D22);
+        border(g, x, y, w, h, 0x44FFFFFF);
+        String mid = STATE.selectedModelId;
+        if (mid == null || mid.isBlank()) {
+            drawMuted(g, Component.translatable("gui.sparkle_morpher.model_panel.select_model"), x + 8, y + h / 2);
+            return;
+        }
+        ModelAssembly asm = residentAssembly(mid);
+        if (asm != null) {
+            renderSelectedModelPreview(g, asm, mid, x + 4, y + 4, w - 8, h - 24, mouseX, mouseY, partialTick);
+        } else {
+            drawMuted(g, Component.literal("…"), x + w / 2 - 4, y + h / 2);
+        }
+        String name = asm == null ? mid.substring(mid.lastIndexOf('/') + 1) : displayName(mid, asm);
+        String line = trim(name, w - 8);
+        g.text(this.font, Component.literal(line), x + (w - this.font.width(line)) / 2, y + h - 11, CAT_NAME, false);
+    }
+
+    private void renderYsmFilterIcon(GuiGraphicsExtractor g, int mouseX, int mouseY, int x, int y,
+                                     ModelPanelState.ModelFilter filter, IconGlyph icon, Component tooltip) {
+        boolean selected = STATE.modelFilter == filter;
+        boolean hover = inside(mouseX, mouseY, x, y, 18, 18);
+        fill(g, x, y, 18, 18, selected ? CAT_SELECT : hover ? CAT_BASE_HOVER : CAT_BASE);
+        border(g, x, y, 18, 18, selected ? RED : hover ? CAT_STAR_BORDER : 0x33FFFFFF);
+        drawIcon(g, icon, x + 1, y + 1);
+        hit(x, y, 18, 18, tooltip, () -> setModelFilter(filter));
+    }
+
+    private List<String> wrapText(String text, int maxWidth, int maxLines) {
+        List<String> lines = new ArrayList<>();
+        if (text == null || text.isEmpty() || maxLines <= 0) {
+            return lines;
+        }
+        int start = 0;
+        int width = 0;
+        int total = text.codePointCount(0, text.length());
+        for (int k = 0; k < total; k++) {
+            int cp = text.codePointAt(text.offsetByCodePoints(0, k));
+            int cw = this.font.width(new String(Character.toChars(cp)));
+            if (k > start && width + cw > maxWidth) {
+                lines.add(text.substring(text.offsetByCodePoints(0, start), text.offsetByCodePoints(0, k)));
+                start = k;
+                width = 0;
+                if (lines.size() == maxLines - 1) {
+                    break;
+                }
+            }
+            width += cw;
+        }
+        if (lines.size() < maxLines) {
+            lines.add(trim(text.substring(text.offsetByCodePoints(0, start)), maxWidth));
+        }
+        return lines;
+    }
+
     private void renderCurrentModelSummary(GuiGraphicsExtractor g, int x, int y, int w) {
         LocalPlayer player = Minecraft.getInstance().player;
         String model = "default";
@@ -750,7 +959,6 @@ public class ModernPlayerModelScreen extends Screen {
         evictCardPreviews(pageIds);
     }
 
-    /** 单张竖卡:实时 3D 小人 / 紫色文件夹卡 / 懒模型加载小圆点。 */
     private void renderCatalogCard(GuiGraphicsExtractor g, int mouseX, int mouseY, ModelEntry entry, int cx, int cy, int cw, int ch, Set<String> starredModels, float partialTick) {
         boolean folder = entry.folder();
         boolean selected = entry.modelId().equals(STATE.selectedModelId) || this.selectedModelIds.contains(entry.modelId());
@@ -758,42 +966,46 @@ public class ModernPlayerModelScreen extends Screen {
         boolean hover = inside(mouseX, mouseY, cx, cy, cw, ch);
         boolean starred = !folder && starredModels.contains(entry.modelId());
         boolean locked = !folder && entry.locked();
-        int nameH = clamp((int) (ch * 0.24f), 20, 46);
-        int coverH = Math.max(1, ch - nameH);
+        int figureH = Math.max(1, ch - 20);
+
+        fill(g, cx, cy, cw, ch, folder ? CAT_FOLDER : CAT_BASE);
 
         if (folder) {
-            fill(g, cx, cy, cw, ch, hover ? CAT_FOLDER_HOVER : CAT_FOLDER);
+            ModelPackData pack = ClientModelManager.getModelPackMap().get(entry.modelId());
+            AbstractTexture packIcon = pack == null ? null : pack.getTexture();
+            if (packIcon != null) {
+                drawCoverStretch(g, packIcon, cx, cy, cw, ch);
+            } else {
+                g.blit(DEFAULT_PACK_ICON, cx, cy, cx + cw, cy + ch, 0.0f, 1.0f, 0.0f, 1.0f);
+            }
+        } else if (locked) {
+            int size = Math.min(26, cw - 12);
+            drawIconScaled(g, IconGlyph.LOCK, cx + Math.max(0, (cw - size) / 2), cy + Math.max(2, (figureH - size) / 2), size);
         } else {
-            fill(g, cx, cy, cw, ch, selected ? CAT_SELECT : hover ? CAT_BASE_HOVER : CAT_BASE);
-        }
-
-        if (folder) {
-            int size = Math.min(34, Math.min(cw - 12, coverH - 12));
-            drawIconScaled(g, IconGlyph.FOLDER, cx + Math.max(0, (cw - size) / 2), cy + Math.max(2, (coverH - size) / 2), size);
-        } else if (!locked) {
             ModelAssembly asm = residentAssembly(entry.modelId());
             if (asm == null) {
-                drawCatalogLoading(g, cx, cy, cw, coverH);
+                drawCatalogLoading(g, cx, cy, cw, figureH);
             } else if (asm.isGltf()) {
-                int size = Math.min(30, Math.min(cw - 8, coverH - 10));
-                drawIconScaled(g, IconGlyph.MODEL, cx + Math.max(0, (cw - size) / 2), cy + Math.max(2, (coverH - size) / 2), size);
+                int size = Math.min(26, Math.min(cw - 8, figureH - 12));
+                drawIconScaled(g, IconGlyph.MODEL, cx + Math.max(0, (cw - size) / 2), cy + Math.max(2, (figureH - size) / 2), size);
             } else {
                 AbstractTexture cover = coverTextureOf(asm);
-                if (cover != null && drawCoverImage(g, cover, cx + 2, cy + 2, cw - 4, coverH - 2)) {
-                    fill(g, cx, cy, cw, coverH, 0x8C000000); // 封面压暗当底,凸显上面的实时小人
+                ModelDisplayAssets displayAssets = asm.getTextureRegistry();
+                AbstractTexture foreground = displayAssets == null ? null : displayAssets.getGuiForeground();
+                if (cover != null) {
+                    drawCoverStretch(g, cover, cx, cy, cw, ch);
                 }
-                renderCatalogCardFigure(g, entry.modelId(), asm, cx, cy, cw, coverH, partialTick);
+                String textureId = selectedTextureOrDefault(asm);
+                PlayerPreviewEntity cardEntity = cardPreviewEntityFor(entry.modelId(), textureId);
+                this.cardAnimator.update(entry.modelId(), cardEntity, hover, System.currentTimeMillis());
+                renderCatalogCardFigure(g, entry.modelId(), asm, cx, cy, cw, figureH, partialTick);
+                if (foreground != null) {
+                    drawCoverStretch(g, foreground, cx, cy, cw, ch);
+                }
             }
         }
 
-        // 名字条:压在 3D 之后,保证不被小人遮挡
-        fill(g, cx, cy + coverH, cw, nameH, 0xC6000000);
-        drawCatalogName(g, entry, cx, cy + coverH, cw, nameH, folder);
-
-        if (locked) {
-            fill(g, cx, cy, cw, ch, CAT_DIM);
-            drawIcon(g, IconGlyph.LOCK, cx + (cw - 18) / 2, cy + Math.max(2, (coverH - 18) / 2));
-        } else if (!folder) {
+        if (!locked) {
             if (multiSelected) {
                 drawIcon(g, IconGlyph.CHECK, cx + cw - 18, cy + 3);
             } else if (starred) {
@@ -801,8 +1013,44 @@ public class ModernPlayerModelScreen extends Screen {
             }
         }
 
-        border(g, cx, cy, cw, ch, selected ? RED : hover ? CAT_STAR_BORDER : 0x55FFFFFF);
-        hit(cx, cy, cw, ch, Component.literal(entry.title()), () -> clickModelEntry(entry));
+        String cardTitle = entry.title();
+        if (cardTitle == null || cardTitle.isEmpty()) {
+            String raw = entry.modelId();
+            if (raw != null) {
+                cardTitle = raw.substring(raw.lastIndexOf('/') + 1);
+            } else {
+                cardTitle = "";
+            }
+        }
+        List<String> nameLines = wrapText(cardTitle, Math.max(6, cw - 6), 2);
+        if (nameLines.isEmpty()) {
+            nameLines.add(trim(cardTitle, Math.max(6, cw - 6)));
+        }
+        int nameTy = cy + ch - (nameLines.size() > 1 ? 19 : 15);
+        int nameColor = folder ? 0xFF2B2B2B : CAT_NAME;
+        for (int li = 0; li < nameLines.size(); li++) {
+            String line = nameLines.get(li);
+            int tx = cx + (cw - this.font.width(line)) / 2;
+            int ty = nameTy + li * this.font.lineHeight;
+            g.text(this.font, Component.literal(line), tx, ty, nameColor, false);
+        }
+
+        if (locked) {
+            fill(g, cx, cy, cw, ch, CAT_DIM);
+        }
+
+        if (!folder && !locked && hover) {
+            fill(g, cx, cy + 1, 1, ch - 2, CAT_NAME);
+            fill(g, cx, cy, cw, 1, CAT_NAME);
+            fill(g, cx + cw - 1, cy + 1, 1, ch - 2, CAT_NAME);
+            fill(g, cx, cy + ch - 1, cw, 1, CAT_NAME);
+        }
+        if (locked) {
+            hit(cx, cy, cw, ch, Component.literal(entry.title()), () -> {
+            });
+        } else {
+            hit(cx, cy, cw, ch, Component.literal(entry.title()), () -> clickModelEntry(entry));
+        }
     }
 
     /** 卡片底部名字条。名字够高(≥28)且有条目副标题时排两行,否则单行居中。 */
@@ -820,14 +1068,12 @@ public class ModernPlayerModelScreen extends Screen {
         }
     }
 
-    /** 懒模型未常驻:在卡片上部画加载提示小圆点。 */
     private void drawCatalogLoading(GuiGraphicsExtractor g, int cx, int cy, int cw, int coverH) {
-        int dots = (this.preloadTicker / 3) % 4;
+        int dots = (int) ((System.currentTimeMillis() / 250L) % 4L);
         String s = "." + ".".repeat(dots);
         g.text(this.font, Component.literal(s), cx + (cw - this.font.width(s)) / 2, cy + Math.max(6, (coverH - this.font.lineHeight) / 2), CAT_NAME, false);
     }
 
-    /** 卡片里该模型的实时 3D 小人(与右栏详情同一渲染管线、静止正面;带封面时已垫压暗底)。 */
     private void renderCatalogCardFigure(GuiGraphicsExtractor g, String modelId, ModelAssembly asm, int cx, int cy, int cw, int coverH, float partialTick) {
         if (cw < 14 || coverH < 22) {
             return;
@@ -839,10 +1085,19 @@ public class ModernPlayerModelScreen extends Screen {
             if (entity == null || !entity.isModelReady()) {
                 return;
             }
-            float scale = clamp(coverH * 0.5f, 16.0f, 170.0f);
+            boolean disableRotation;
+            try {
+                var props = asm.getModelData().getModelProperties();
+                disableRotation = props != null && props.isDisablePreviewRotation();
+            } catch (Exception ignored) {
+                disableRotation = false;
+            }
+            float[] cam = YSM_CAM[disableRotation ? 0 : 1];
+            float scale = clamp(coverH * (cam[0] / 70.0f), 16.0f, 170.0f);
             ModelPreviewRenderer.renderLivingEntityPreview(g, cx, cy, cx + cw, cy + coverH,
-                    cx + cw / 2.0f, cy + coverH - 2.0f, scale, partialTick, entity,
-                    RendererManager.getPlayerRenderer(), true, true);
+                    cx + cw / 2.0f, cy + coverH - cam[1], scale, partialTick, entity,
+                    RendererManager.getPlayerRenderer(), disableRotation, true,
+                    Integer.MIN_VALUE, Integer.MIN_VALUE, cam[2], cam[3]);
         } catch (Exception ignored) {
             int size = Math.min(26, Math.min(cw - 8, coverH - 10));
             drawIconScaled(g, IconGlyph.MODEL, cx + Math.max(0, (cw - size) / 2), cy + Math.max(2, (coverH - size) / 2), size);
@@ -876,6 +1131,11 @@ public class ModernPlayerModelScreen extends Screen {
     /** 只保留当前页上的卡片预览实体,翻页即释放上一页(防止实体/资源堆积)。 */
     private void evictCardPreviews(Set<String> keep) {
         if (this.cardPreviewEntities.size() > keep.size()) {
+            for (String old : this.cardPreviewEntities.keySet()) {
+                if (!keep.contains(old)) {
+                    this.cardAnimator.forget(old);
+                }
+            }
             this.cardPreviewEntities.keySet().retainAll(keep);
             this.cardPreviewTextureIds.keySet().retainAll(keep);
         }
@@ -1061,6 +1321,14 @@ public class ModernPlayerModelScreen extends Screen {
         return background != null ? background : assets.getGuiForeground();
     }
 
+    private Identifier coverResource(AbstractTexture tex, int[] dims) {
+        IResourceLocatable locatable = UploadManager.getOrCreateLocatable(tex, true);
+        if (locatable == null && tex instanceof OuterFileTexture) {
+            locatable = UploadManager.getOrCreateLocatableWithSize(tex, true, Math.max(64, dims[0]));
+        }
+        return locatable == null ? null : locatable.getResourceLocationOrNull();
+    }
+
     /** 把封面等比 fit 进 (x,y,w,h),居中不拉伸。无法获得资源/尺寸时返回 false。 */
     private boolean drawCoverImage(GuiGraphicsExtractor g, AbstractTexture tex, int x, int y, int w, int h) {
         if (tex == null || w <= 0 || h <= 0) {
@@ -1070,11 +1338,7 @@ public class ModernPlayerModelScreen extends Screen {
         if (dims == null) {
             return false;
         }
-        IResourceLocatable locatable = UploadManager.getOrCreateLocatable(tex, true);
-        if (locatable == null) {
-            return false;
-        }
-        Identifier loc = locatable.getResourceLocationOrNull();
+        Identifier loc = coverResource(tex, dims);
         if (loc == null) {
             return false;
         }
@@ -1086,6 +1350,22 @@ public class ModernPlayerModelScreen extends Screen {
         int x0 = x + (w - dw) / 2;
         int y0 = y + (h - dh) / 2;
         g.blit(loc, x0, y0, x0 + dw, y0 + dh, 0.0f, 1.0f, 0.0f, 1.0f);
+        return true;
+    }
+
+    private boolean drawCoverStretch(GuiGraphicsExtractor g, AbstractTexture tex, int x, int y, int w, int h) {
+        if (tex == null || w <= 0 || h <= 0) {
+            return false;
+        }
+        int[] dims = coverDimensions(tex);
+        if (dims == null) {
+            return false;
+        }
+        Identifier loc = coverResource(tex, dims);
+        if (loc == null) {
+            return false;
+        }
+        g.blit(loc, x, y, x + w, y + h, 0.0f, 1.0f, 0.0f, 1.0f);
         return true;
     }
 
@@ -1238,8 +1518,7 @@ public class ModernPlayerModelScreen extends Screen {
     private void preloadVisibleCovers() {
         if (STATE.activeTab != ModelPanelState.Tab.MODEL
                 || STATE.secondaryPanel != ModelPanelState.SecondaryPanel.NONE
-                || this.layout == null
-                || !modelCardsActive()) {
+                || this.layout == null) {
             return;
         }
         List<ModelEntry> entries = collectModelEntries();
@@ -1761,13 +2040,9 @@ public class ModernPlayerModelScreen extends Screen {
         }
         switch (STATE.activeTab) {
             case MODEL -> {
-                if (modelCardsActive()) {
-                    List<ModelEntry> pageEntries = collectModelEntries();
-                    int pages = pageEntries.isEmpty() ? 1 : catalogMetrics(modelListW(), currentModelGridH(), pageEntries.size()).totalPages();
-                    STATE.modelScroll = clamp(STATE.modelScroll + delta, 0, pages - 1);
-                } else {
-                    STATE.modelScroll = Math.max(0, STATE.modelScroll + delta * modelWheelStep());
-                }
+                int perPage = ysmGridMetrics()[2];
+                int pages = Math.max(1, (modelYsmEntries().size() + perPage - 1) / perPage);
+                STATE.modelScroll = clamp(STATE.modelScroll + delta, 0, pages - 1);
             }
             case RESOURCE -> STATE.resourceScroll = Math.max(0, STATE.resourceScroll + delta);
             case SETTINGS -> STATE.settingsScroll = Math.max(0, STATE.settingsScroll + delta);

--- a/fabric/src/main/java/com/micaftic/morpher/client/gui/ModernPlayerModelScreen.java
+++ b/fabric/src/main/java/com/micaftic/morpher/client/gui/ModernPlayerModelScreen.java
@@ -118,10 +118,12 @@ public class ModernPlayerModelScreen extends Screen {
     private static final int CAT_DIM = 0x9F222222;         // 需授权压暗
     private static final int CAT_MARGIN = 6;
     private static final int CAT_PAD = 4;                  // 卡间距
-    private static final int CAT_COLS_MAX = 5;             // 一页最多 5 列
-    private static final int CAT_ROWS = 2;                 // 一页 2 行
-    private static final int CAT_MIN_W = 220;              // 进入卡片页的最小网格宽
-    private static final int CAT_MIN_H = 170;              // 进入卡片页的最小网格高
+    private static final int CAT_MAX_COLS = 8;             // 一页最多 8 列
+    private static final int CAT_MAX_ROWS = 3;             // 一页最多 3 行(实时 3D 卡,留性能余量)
+    private static final int CAT_MIN_CELL_W = 64;          // 卡片最小宽(保证可读)
+    private static final int CAT_MAX_CELL_W = 170;         // 卡片最大宽
+    private static final int CAT_MIN_W = 140;              // 进入卡片页的最小网格宽
+    private static final int CAT_MIN_H = 120;              // 进入卡片页的最小网格高
     private static final float CAT_ASPECT = 1.73f;         // 竖卡比例 52:90
     private static final int PRELOAD_BUDGET = 4;         // 每 tick 最多新启动的预载数
     private static final int PRELOAD_GIVE_UP_TICKS = 400; // 预载观察超时(约20秒),超时未落地判为失败
@@ -446,43 +448,48 @@ public class ModernPlayerModelScreen extends Screen {
         return this.layout.contentWidth < 680 || this.layout.contentHeight < 260;
     }
 
-    private boolean compactModelLayout() {
-        return listPriority();
+    /** 右详情栏:内容区够宽够高才画在右侧;否则详情退回底部条。旧二值 compact 会整体丢掉右栏,这里拆成独立档位。 */
+    private boolean modelDetailsRight() {
+        return this.layout.contentWidth >= 520 && this.layout.contentHeight >= 200;
+    }
+
+    /** 左摘要栏:在右栏基础上再多要一行宽/高;不足则标题/筛选/动作改为列表列顶部的内联行。 */
+    private boolean modelHeaderWide() {
+        return modelDetailsRight() && this.layout.contentWidth >= 720 && this.layout.contentHeight >= 280;
     }
 
     private int modelLeftW() {
-        if (compactModelLayout()) {
+        if (!modelHeaderWide()) {
             return 0;
         }
-        int minList = modelListMinW();
-        int max = Math.max(72, Math.min(140, this.layout.contentWidth - minList - 86 - 28));
-        return clamp(this.layout.contentWidth / 4, 72, max);
+        int free = this.layout.contentWidth - modelRightW() - modelListMinW() - 46;
+        return clamp(this.layout.contentWidth / 6, 140, Math.max(140, Math.min(220, free)));
     }
 
     private int modelRightW() {
-        if (compactModelLayout()) {
+        if (!modelDetailsRight()) {
             return 0;
         }
-        int max = Math.max(72, Math.min(180, this.layout.contentWidth - modelLeftW() - modelListMinW() - 28));
-        return clamp(this.layout.contentWidth / 3, 72, max);
+        int cap = Math.max(150, Math.min(250, this.layout.contentWidth - 240));
+        return clamp(this.layout.contentWidth / 4, 150, cap);
     }
 
     private int modelListX() {
-        if (compactModelLayout()) {
-            return this.layout.contentLeft + 8;
+        if (modelHeaderWide()) {
+            return modelLeftX() + modelLeftW() + 12;
         }
-        return modelLeftX() + modelLeftW() + 10;
+        return this.layout.contentLeft + 8;
     }
 
     private int modelListW() {
-        if (compactModelLayout()) {
-            return Math.max(60, this.layout.contentWidth - 16);
-        }
-        return Math.max(24, this.layout.contentWidth - modelLeftW() - modelRightW() - 28);
+        int left = modelLeftW();
+        int right = modelRightW();
+        int used = 16 + (left > 0 ? left + 12 : 0) + (right > 0 ? right + 12 : 0);
+        return Math.max(modelListMinW(), this.layout.contentWidth - used);
     }
 
     private int modelListMinW() {
-        return this.layout.contentWidth < 420 ? 54 : 90;
+        return this.layout.contentWidth < 560 ? 110 : 180;
     }
 
     private int resourceListX() {
@@ -532,7 +539,7 @@ public class ModernPlayerModelScreen extends Screen {
     }
 
     private void renderModelTab(GuiGraphicsExtractor g, int mouseX, int mouseY, float partialTick) {
-        boolean compact = compactModelLayout();
+        boolean sideDetails = modelDetailsRight();
         int x = modelLeftX();
         int y = this.layout.contentTop + 8;
         int leftW = modelLeftW();
@@ -542,7 +549,7 @@ public class ModernPlayerModelScreen extends Screen {
         int detailX = listX + listW + 10;
         int contentBottom = this.layout.footerTop - 6;
 
-        if (compact) {
+        if (!modelHeaderWide()) {
             int filtersY = y + 24;
             renderChip(g, listX, filtersY, 38, Component.translatable("gui.sparkle_morpher.model_panel.filter.all"), STATE.modelFilter == ModelPanelState.ModelFilter.ALL, () -> setModelFilter(ModelPanelState.ModelFilter.ALL));
             renderChip(g, listX + 42, filtersY, 42, Component.translatable("gui.sparkle_morpher.model_panel.filter.auth"), STATE.modelFilter == ModelPanelState.ModelFilter.AUTH, () -> setModelFilter(ModelPanelState.ModelFilter.AUTH));
@@ -580,20 +587,18 @@ public class ModernPlayerModelScreen extends Screen {
         if (this.modelSearchBox != null) {
             this.modelSearchBox.extractWidgetRenderState(g, mouseX, mouseY, partialTick);
         }
-        boolean stackedControls = compact && listW < 260;
-        int pathY = compact ? stackedControls ? y + 68 : y + 48 : y + 30;
+        int pathY = modelPathY();
         renderPathBar(g, listX, pathY, listW);
         int gridY = pathY + 20;
         int actionsBandY = contentBottom - 28;
-        int detailStripH = compactDetailStripH();
-        int reserve = detailStripH > 0 ? detailStripH + 3 : 0;
-        int gridH = Math.max(compact ? 34 : 50, actionsBandY - 4 - reserve - gridY);
+        int gridH = modelListGridHeight();
         renderModelGrid(g, mouseX, mouseY, listX, gridY, listW, gridH, partialTick);
-        if (detailStripH > 0) {
-            renderCompactDetail(g, mouseX, mouseY, listX, gridY + gridH + 3, listW, detailStripH, partialTick);
+        int stripH = compactDetailStripH();
+        if (stripH > 0) {
+            renderCompactDetail(g, mouseX, mouseY, listX, gridY + gridH + 3, listW, stripH, partialTick);
         }
         renderModelBottomActions(g, mouseX, mouseY, listX, actionsBandY, listW, gridH);
-        if (!compact) {
+        if (sideDetails) {
             renderModelDetails(g, mouseX, mouseY, detailX, y, rightW, contentBottom - y, partialTick);
         }
     }
@@ -630,9 +635,8 @@ public class ModernPlayerModelScreen extends Screen {
     }
 
     /**
-     * 模型网格。面积足够大时走「目录卡片页」(52:90 竖卡、每页 ≤5×2 张,
-     * 卡主体为实时 3D 小人),否则退回文字行格。卡片判定只看网格区尺寸,与整窗紧凑模式无关——
-     * 常见 guiScale3 满屏会走 compactModelLayout(),若把卡片也绑在紧凑上,卡片页就永远不出现。
+     * 模型网格。面积足够时走「目录卡片页」(52:90 竖卡,列×行随可用面积自适应,卡主体为实时 3D 小人);
+     * 面积不足则退回文字行格(统一两行,副标题保留)。卡片判定只看网格区实际尺寸,与整窗档位无关。
      */
     private void renderModelGrid(GuiGraphicsExtractor g, int mouseX, int mouseY, int x, int y, int w, int h, float partialTick) {
         glassPanel(g, x, y, w, h);
@@ -683,7 +687,12 @@ public class ModernPlayerModelScreen extends Screen {
     }
 
     private static boolean fitsCatalog(int w, int h) {
-        return w >= CAT_MIN_W && h >= CAT_MIN_H;
+        if (w < CAT_MIN_W || h < CAT_MIN_H) {
+            return false;
+        }
+        // 结构探测:即便过了最小宽高,也要能至少放 1 列 1 行才采用目录页。
+        CatalogMetrics m = catalogMetrics(w, h, 2);
+        return m.cols() >= 1 && m.rows() >= 1;
     }
 
     /** 目录页是否生效(与 renderModelGrid 同源:按当前列表区实际尺寸,不看 compact 整窗标记)。 */
@@ -693,31 +702,37 @@ public class ModernPlayerModelScreen extends Screen {
                 && fitsCatalog(modelListW(), currentModelGridH());
     }
 
-    /** 目录页排版:每页 ≤5 列 × 2 行,52:90 竖卡等比缩放去填满网格区;STATE.modelScroll 在目录模式下表示页号。 */
-    private CatalogMetrics catalogMetrics(int w, int h, int entryCount) {
-        int cols = clamp((w - 2 * CAT_MARGIN + CAT_PAD) / (40 + CAT_PAD), 1, CAT_COLS_MAX);
+    /**
+     * 目录页排版:宽推列、高推行(列×行随面积自适应,最多 CAT_MAX_COLS×CAT_MAX_ROWS),
+     * 卡宽取宽/高两方向都放得下的值,STATE.modelScroll 在目录模式下表示页号。
+     */
+    private static CatalogMetrics catalogMetrics(int w, int h, int entryCount) {
+        int cols = clamp((w - 2 * CAT_MARGIN + CAT_PAD) / (CAT_MIN_CELL_W + CAT_PAD), 1, CAT_MAX_COLS);
+        int rows = clamp((h - 2 * CAT_MARGIN + CAT_PAD) / ((int) (CAT_MIN_CELL_W * CAT_ASPECT) + CAT_PAD), 1, CAT_MAX_ROWS);
         int wFit = (w - 2 * CAT_MARGIN - (cols - 1) * CAT_PAD) / cols;
-        int hFit = (int) ((h - 2 * CAT_MARGIN - (CAT_ROWS - 1) * CAT_PAD) / (CAT_ROWS * CAT_ASPECT));
-        int cellW = clamp(Math.min(wFit, hFit), 32, 170);
+        int hFit = (int) ((h - 2 * CAT_MARGIN - (rows - 1) * CAT_PAD) / (rows * CAT_ASPECT));
+        int cellW = clamp(Math.min(wFit, hFit), CAT_MIN_CELL_W, CAT_MAX_CELL_W);
+        cols = clamp((w - 2 * CAT_MARGIN + CAT_PAD) / (cellW + CAT_PAD), 1, cols);
         int cellH = Math.max(1, (int) Math.floor(cellW * CAT_ASPECT));
-        int capacity = Math.max(1, cols * CAT_ROWS);
+        rows = clamp((h - 2 * CAT_MARGIN + CAT_PAD) / (cellH + CAT_PAD), 1, rows);
+        int capacity = cols * rows;
         int totalPages = entryCount == 0 ? 1 : (entryCount + capacity - 1) / capacity;
-        return new CatalogMetrics(cols, cellW, cellH, capacity, totalPages);
+        return new CatalogMetrics(cols, rows, cellW, cellH, capacity, totalPages);
     }
 
-    /** 目录卡片页网格:一页 ≤10 卡,整块居中,每张卡 = 实时 3D 小人 + 名字条。 */
+    /** 目录卡片页网格:列×行随面积自适应,整块居中,每张卡 = 实时 3D 小人 + 名字条。 */
     private void renderCatalogGrid(GuiGraphicsExtractor g, int mouseX, int mouseY, List<ModelEntry> entries, int x, int y, int w, int h, float partialTick) {
         CatalogMetrics m = catalogMetrics(w, h, entries.size());
         STATE.modelScroll = clamp(STATE.modelScroll, 0, m.totalPages() - 1);
         int start = STATE.modelScroll * m.capacity();
         int blockW = m.cols() * m.cellW() + (m.cols() - 1) * CAT_PAD;
-        int blockH = CAT_ROWS * m.cellH() + (CAT_ROWS - 1) * CAT_PAD;
+        int blockH = m.rows() * m.cellH() + (m.rows() - 1) * CAT_PAD;
         int x0 = x + Math.max(CAT_MARGIN, (w - blockW) / 2);
         int y0 = y + Math.max(CAT_MARGIN, (h - blockH) / 2);
         Set<String> starred = starModels();
         Set<String> pageIds = new HashSet<>();
         outer:
-        for (int row = 0; row < CAT_ROWS; row++) {
+        for (int row = 0; row < m.rows(); row++) {
             for (int col = 0; col < m.cols(); col++) {
                 int index = start + row * m.cols() + col;
                 if (index >= entries.size()) {
@@ -790,12 +805,12 @@ public class ModernPlayerModelScreen extends Screen {
         hit(cx, cy, cw, ch, Component.literal(entry.title()), () -> clickModelEntry(entry));
     }
 
-    /** 卡片底部名字条。名字够高(≥34)且有条目副标题时排两行,否则单行居中。 */
+    /** 卡片底部名字条。名字够高(≥28)且有条目副标题时排两行,否则单行居中。 */
     private void drawCatalogName(GuiGraphicsExtractor g, ModelEntry entry, int bx, int by, int cw, int nameH, boolean folder) {
         int w = Math.max(6, cw - 6);
         String title = trim(entry.title(), w);
         String sub = entry.subtitle();
-        boolean twoLine = !folder && nameH >= 34 && sub != null && !sub.isEmpty() && !"folder".equals(sub);
+        boolean twoLine = !folder && nameH >= 28 && sub != null && !sub.isEmpty() && !"folder".equals(sub);
         int tx = bx + 3;
         if (twoLine) {
             g.text(this.font, Component.literal(title), tx, by + 3, CAT_NAME, false);
@@ -955,7 +970,7 @@ public class ModernPlayerModelScreen extends Screen {
     }
 
     private ModelListMetrics modelListMetrics(int w, int h, int entryCount) {
-        boolean dense = compactModelLayout() || h < 132;
+        boolean dense = false; // 兜底文字行格统一两行,保证副标题(作者/纹理数)始终可见
         boolean cards = false; // 目录卡片页由 renderCatalogGrid 独占;此处恒为文字行格
         int cellW;
         int cellH;
@@ -971,7 +986,7 @@ public class ModernPlayerModelScreen extends Screen {
             int maxW = dense ? 132 : 150;
             cellW = Math.max(minW, Math.min(maxW, w / Math.max(1, w / targetW)));
             cols = Math.max(1, w / cellW);
-            cellH = dense ? DENSE_MODEL_ROW : h < 90 ? 42 : 50;
+            cellH = dense ? DENSE_MODEL_ROW : h < 110 ? 42 : 50;
         }
         int contentRows = entryCount == 0 ? 0 : (entryCount + cols - 1) / cols;
         int maxScroll = Math.max(0, contentRows * cellH - h);
@@ -1117,15 +1132,24 @@ public class ModernPlayerModelScreen extends Screen {
     }
 
     private int currentModelGridH() {
+        return modelListGridHeight();
+    }
+
+    /** 列表列纵向几何的单一来源:renderModelTab 与各 metrics 消费者共用,避免两处公式漂移。 */
+    private int modelPathY() {
         int y = this.layout.contentTop + 8;
-        int contentBottom = this.layout.footerTop - 6;
-        boolean compact = compactModelLayout();
-        boolean stackedControls = compact && modelListW() < 260;
-        int pathY = compact ? stackedControls ? y + 68 : y + 48 : y + 30;
-        int gridY = pathY + 20;
-        int detailStripH = compactDetailStripH();
-        int reserve = detailStripH > 0 ? detailStripH + 3 : 0;
-        return Math.max(compact ? 34 : 50, contentBottom - 28 - 4 - reserve - gridY);
+        if (modelHeaderWide()) {
+            return y + 30;
+        }
+        return modelListW() < 260 ? y + 68 : y + 48;
+    }
+
+    private int modelListGridHeight() {
+        int bottom = this.layout.footerTop - 6;
+        int stripH = modelDetailsRight() ? 0 : compactDetailStripH(); // 详情在右栏时不再占用底部条空间
+        int reserve = stripH > 0 ? stripH + 3 : 0;
+        int minH = (modelHeaderWide() || modelDetailsRight()) ? 50 : 34;
+        return Math.max(minH, bottom - 28 - 4 - reserve - modelPathY() - 20);
     }
 
     private void renderModelBottomActions(GuiGraphicsExtractor g, int mouseX, int mouseY, int x, int y, int w, int gridH) {
@@ -2866,19 +2890,23 @@ public class ModernPlayerModelScreen extends Screen {
     }
 
     private int compactDetailStripH() {
-        if (!compactModelLayout()) {
+        if (modelDetailsRight()) {
             return 0;
         }
-        return STATE.compactPreviewExpanded ? 112 : 18;
+        boolean hasSel = !STATE.selectedModelId.isBlank();
+        if (hasSel) {
+            return STATE.compactPreviewState == 2 ? 18 : 112; // 选中即自动展开,除非用户手动收起
+        }
+        return STATE.compactPreviewState == 1 ? 112 : 18;
     }
 
     private void renderCompactDetail(GuiGraphicsExtractor g, int mouseX, int mouseY, int x, int y, int w, int h, float partialTick) {
         int barH = 18;
         fill(g, x, y, w, h, GLASS_DARK);
         border(g, x, y, w, h, 0x33FFFFFF);
-        boolean expanded = STATE.compactPreviewExpanded;
+        boolean expanded = h > 18;
         renderIconButton(g, mouseX, mouseY, x + 1, y, expanded ? IconGlyph.MINUS : IconGlyph.PLUS,
-                Component.translatable("gui.sparkle_morpher.model_panel.details"), () -> STATE.compactPreviewExpanded = !STATE.compactPreviewExpanded);
+                Component.translatable("gui.sparkle_morpher.model_panel.details"), () -> STATE.compactPreviewState = expanded ? 2 : 1);
         ModelAssembly assembly = selectedAssembly();
         String modelId = STATE.selectedModelId;
         if (assembly == null) {
@@ -2906,7 +2934,7 @@ public class ModernPlayerModelScreen extends Screen {
                     });
         }
         renderIconButton(g, mouseX, mouseY, x + w - 19, y, IconGlyph.INFO,
-                Component.translatable("gui.sparkle_morpher.model_panel.info"), () -> STATE.compactPreviewExpanded = true);
+                Component.translatable("gui.sparkle_morpher.model_panel.info"), () -> STATE.compactPreviewState = 1);
         if (!expanded) {
             return;
         }
@@ -3026,7 +3054,7 @@ public class ModernPlayerModelScreen extends Screen {
     private record ModelListMetrics(int cellW, int cellH, int cols, int contentRows, int maxScroll, boolean dense, boolean cards) {
     }
 
-    private record CatalogMetrics(int cols, int cellW, int cellH, int capacity, int totalPages) {
+    private record CatalogMetrics(int cols, int rows, int cellW, int cellH, int capacity, int totalPages) {
     }
 
     private record ModelEntry(String modelId, String title, String subtitle, boolean folder, boolean locked) {

--- a/fabric/src/main/java/com/micaftic/morpher/client/gui/ModernPlayerModelScreen.java
+++ b/fabric/src/main/java/com/micaftic/morpher/client/gui/ModernPlayerModelScreen.java
@@ -12,6 +12,7 @@ import com.micaftic.morpher.client.gui.resource.ModelRepoClient;
 import com.micaftic.morpher.client.gui.resource.ModelRepoEntry;
 import com.micaftic.morpher.client.gui.resource.ResourceDownloadManager;
 import com.micaftic.morpher.client.gui.resource.ResourceStationConfig;
+import com.micaftic.morpher.client.gui.metadata.ModelDisplayAssets;
 import com.micaftic.morpher.client.model.ModelAssembly;
 import com.micaftic.morpher.client.renderer.ModelPreviewRenderer;
 import com.micaftic.morpher.client.renderer.RendererManager;
@@ -42,8 +43,12 @@ import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
+import com.micaftic.morpher.client.texture.OuterFileTexture;
+import com.micaftic.morpher.client.upload.IResourceLocatable;
+import com.micaftic.morpher.client.upload.UploadManager;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import org.apache.commons.lang3.StringUtils;
 
@@ -57,9 +62,12 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.HexFormat;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
@@ -90,6 +98,35 @@ public class ModernPlayerModelScreen extends Screen {
     private static final int MODEL_PAGE_BUTTON_WIDTH = 46;
     private static final int MODEL_PAGE_BUTTON_HEIGHT = 18;
     private static final int ICON = 18;
+    private static final int NAME_BAND = 34;             // (legacy 大卡,已弃用)
+    private static final int CARD_MIN_W = 150;           // (legacy 大卡,已弃用)
+    private static final int CARD_MIN_H = 168;           // (legacy 大卡,已弃用)
+    private static final int CARD_TARGET_W = 140;        // (legacy 大卡,已弃用)
+    private static final int CARD_MAX_W = 216;           // (legacy 大卡,已弃用)
+    private static final int CARD_MIN_CELL_W = 124;      // (legacy 大卡,已弃用)
+    private static final int CARD_MAX_CELL_H = 208;      // (legacy 大卡,已弃用)
+
+    // ---- 目录卡片页(52:90 竖卡、每页 ≤5 列 × 2 行) ----
+    private static final int CAT_BASE = 0xFF434242;        // 卡片底
+    private static final int CAT_BASE_HOVER = 0xFF505755;  // 悬停
+    private static final int CAT_SELECT = 0xFF58636E;      // 选中
+    private static final int CAT_FOLDER = 0xFF9B51E0;      // 资源包/文件夹 = 紫色卡
+    private static final int CAT_FOLDER_HOVER = 0xFFB17BEA;
+    private static final int CAT_NAME = 0xFFF3EFE0;        // 卡名(奶油色)
+    private static final int CAT_STAR_BORDER = 0xFFF3EFE0; // 悬停奶油描边
+    private static final int CAT_DIM = 0x9F222222;         // 需授权压暗
+    private static final int CAT_MARGIN = 6;
+    private static final int CAT_PAD = 4;                  // 卡间距
+    private static final int CAT_COLS_MAX = 5;             // 一页最多 5 列
+    private static final int CAT_ROWS = 2;                 // 一页 2 行
+    private static final int CAT_MIN_W = 220;              // 进入卡片页的最小网格宽
+    private static final int CAT_MIN_H = 170;              // 进入卡片页的最小网格高
+    private static final float CAT_ASPECT = 1.73f;         // 竖卡比例 52:90
+    private static final int PRELOAD_BUDGET = 4;         // 每 tick 最多新启动的预载数
+    private static final int PRELOAD_GIVE_UP_TICKS = 400; // 预载观察超时(约20秒),超时未落地判为失败
+    private static final int WHEEL_STEP_MAX = 28;        // 模型网格单次滚轮的像素步长上限
+    /** 封面尺寸缓存:gui 封面 texture 实例 -> [宽,高]。键是弱引用,随 assembly 一起回收。 */
+    private static final WeakHashMap<AbstractTexture, int[]> COVER_DIMS = new WeakHashMap<>();
     private static final ExecutorService RESOURCE_EXECUTOR = SmExecutors.pool(SmExecutors.Pool.MODEL_IO);
 
     private final List<Hit> hits = new ArrayList<>();
@@ -98,6 +135,9 @@ public class ModernPlayerModelScreen extends Screen {
     private final Set<String> selectedResourceUrls = new LinkedHashSet<>();
     private final Queue<ModelImportFilePicker.PickedFile> pendingImports = new ArrayDeque<>();
     private final PlayerPreviewEntity previewEntity = new PlayerPreviewEntity();
+    /** 目录卡片页:每卡一个实时 3D 预览实体(按 modelId 缓存,仅保留当页 ≤10)。 */
+    private final Map<String, PlayerPreviewEntity> cardPreviewEntities = new LinkedHashMap<>(16);
+    private final Map<String, String> cardPreviewTextureIds = new LinkedHashMap<>(16);
     private final Screen parentScreen;
     private final BiConsumer<String, String> modelSelectionTarget;
     private ModelPanelLayout layout;
@@ -115,6 +155,10 @@ public class ModernPlayerModelScreen extends Screen {
     private String previewModelId = "";
     private String previewTextureId = "";
     private String pendingModelApplyId;
+    private final Set<String> preloadFailed = new HashSet<>();
+    private final Set<String> preloadWatching = new HashSet<>();
+    private final Map<String, Integer> preloadWatchStart = new LinkedHashMap<>();
+    private int preloadTicker;
 
     private enum IconGlyph {
         MODEL(0, 0),
@@ -269,6 +313,9 @@ public class ModernPlayerModelScreen extends Screen {
         super.tick();
         ResourceDownloadManager.tick();
         pollImports();
+        if ((++this.preloadTicker & 3) == 0) {
+            preloadVisibleCovers();
+        }
         if (this.pendingModelApplyId != null) {
             String pendingId = this.pendingModelApplyId;
             ClientModelManager.getModelContext(pendingId).ifPresent(assembly -> {
@@ -532,7 +579,7 @@ public class ModernPlayerModelScreen extends Screen {
         int detailStripH = compactDetailStripH();
         int reserve = detailStripH > 0 ? detailStripH + 3 : 0;
         int gridH = Math.max(compact ? 34 : 50, actionsBandY - 4 - reserve - gridY);
-        renderModelGrid(g, mouseX, mouseY, listX, gridY, listW, gridH);
+        renderModelGrid(g, mouseX, mouseY, listX, gridY, listW, gridH, partialTick);
         if (detailStripH > 0) {
             renderCompactDetail(g, mouseX, mouseY, listX, gridY + gridH + 3, listW, detailStripH, partialTick);
         }
@@ -573,67 +620,491 @@ public class ModernPlayerModelScreen extends Screen {
         });
     }
 
-    private void renderModelGrid(GuiGraphicsExtractor g, int mouseX, int mouseY, int x, int y, int w, int h) {
+    /**
+     * 模型网格。面积足够大时走「目录卡片页」(52:90 竖卡、每页 ≤5×2 张,
+     * 卡主体为实时 3D 小人),否则退回文字行格。卡片判定只看网格区尺寸,与整窗紧凑模式无关——
+     * 常见 guiScale3 满屏会走 compactModelLayout(),若把卡片也绑在紧凑上,卡片页就永远不出现。
+     */
+    private void renderModelGrid(GuiGraphicsExtractor g, int mouseX, int mouseY, int x, int y, int w, int h, float partialTick) {
         glassPanel(g, x, y, w, h);
-        Set<String> starredModels = starModels();
         List<ModelEntry> entries = collectModelEntries();
-        ModelListMetrics metrics = modelListMetrics(w, h, entries.size());
-        STATE.modelScroll = clamp(STATE.modelScroll, 0, metrics.maxScroll());
         if (entries.isEmpty()) {
             drawCentered(g, Component.translatable("gui.sparkle_morpher.model_panel.no_models"), x + w / 2, y + h / 2 - 4, MUTED);
             return;
         }
-        int start = STATE.modelScroll * metrics.cols();
-        for (int i = 0; i < metrics.rows() * metrics.cols() && start + i < entries.size(); i++) {
-            ModelEntry entry = entries.get(start + i);
-            int cx = x + (i % metrics.cols()) * metrics.cellW() + 3;
-            int cy = y + (i / metrics.cols()) * metrics.cellH() + 3;
-            int cw = metrics.cellW() - 6;
-            int ch = metrics.cellH() - 6;
-            boolean selected = entry.modelId().equals(STATE.selectedModelId) || this.selectedModelIds.contains(entry.modelId());
-            boolean hover = inside(mouseX, mouseY, cx, cy, cw, ch);
-            boolean starred = !entry.folder() && starredModels.contains(entry.modelId());
-            fill(g, cx, cy, cw, ch, selected ? PANEL_ACTIVE : hover ? PANEL_HOVER : 0x3E30363B);
-            border(g, cx, cy, cw, ch, selected ? RED : 0x33FFFFFF);
-            int iconY = metrics.dense() ? cy + Math.max(0, (ch - 16) / 2) : cy + 3;
-            drawIcon(g, entry.folder() ? IconGlyph.FOLDER : entry.locked() ? IconGlyph.LOCK : IconGlyph.MODEL, cx + 4, iconY);
-            if (metrics.dense()) {
-                if (starred) {
-                    drawIcon(g, IconGlyph.STAR, cx + cw - 18, iconY);
-                }
-                int titleW = starred ? cw - 44 : cw - 26;
-                drawText(g, Component.literal(trim(entry.title(), titleW)), cx + 22, cy + (ch - this.font.lineHeight) / 2 + 1);
-            } else {
-                if (starred) {
-                    drawIcon(g, IconGlyph.STAR, cx + cw - 16, cy + metrics.cellH() - 22);
-                }
-                drawText(g, Component.literal(trim(entry.title(), cw - 28)), cx + 22, cy + 6);
-                drawMuted(g, Component.literal(trim(entry.subtitle(), cw - 12)), cx + 6, cy + 22);
-            }
-            hit(cx, cy, cw, ch, Component.literal(entry.title()), () -> clickModelEntry(entry));
+        if (fitsCatalog(w, h)) {
+            renderCatalogGrid(g, mouseX, mouseY, entries, x, y, w, h, partialTick);
+            return;
         }
+        Set<String> starredModels = starModels();
+        ModelListMetrics metrics = modelListMetrics(w, h, entries.size());
+        STATE.modelScroll = clamp(STATE.modelScroll, 0, metrics.maxScroll());
+        int cols = metrics.cols();
+        int cellW = metrics.cellW();
+        int cellH = metrics.cellH();
+        int contentRows = metrics.contentRows();
+        int scroll = STATE.modelScroll;
+        int startRow = Math.min(contentRows - 1, Math.max(0, scroll / Math.max(1, cellH)));
+        g.enableScissor(x, y, x + w, y + h);
+        try {
+            for (int row = startRow; row < contentRows; row++) {
+                int rowTop = y + row * cellH - scroll;
+                if (rowTop >= y + h) {
+                    break;
+                }
+                if (rowTop + cellH <= y) {
+                    continue;
+                }
+                for (int col = 0; col < cols; col++) {
+                    int index = row * cols + col;
+                    if (index >= entries.size()) {
+                        break;
+                    }
+                    ModelEntry entry = entries.get(index);
+                    int cx = x + col * cellW + 3;
+                    int cy = rowTop + 3;
+                    int cw = cellW - 6;
+                    int ch = cellH - 6;
+                    renderLegacyCell(g, mouseX, mouseY, entry, cx, cy, cw, ch, y, y + h, metrics.dense(), starredModels);
+                }
+            }
+        } finally {
+            g.disableScissor();
+        }
+    }
+
+    private static boolean fitsCatalog(int w, int h) {
+        return w >= CAT_MIN_W && h >= CAT_MIN_H;
+    }
+
+    /** 目录页是否生效(与 renderModelGrid 同源:按当前列表区实际尺寸,不看 compact 整窗标记)。 */
+    private boolean modelCardsActive() {
+        return this.layout != null
+                && STATE.secondaryPanel == ModelPanelState.SecondaryPanel.NONE
+                && fitsCatalog(modelListW(), currentModelGridH());
+    }
+
+    /** 目录页排版:每页 ≤5 列 × 2 行,52:90 竖卡等比缩放去填满网格区;STATE.modelScroll 在目录模式下表示页号。 */
+    private CatalogMetrics catalogMetrics(int w, int h, int entryCount) {
+        int cols = clamp((w - 2 * CAT_MARGIN + CAT_PAD) / (40 + CAT_PAD), 1, CAT_COLS_MAX);
+        int wFit = (w - 2 * CAT_MARGIN - (cols - 1) * CAT_PAD) / cols;
+        int hFit = (int) ((h - 2 * CAT_MARGIN - (CAT_ROWS - 1) * CAT_PAD) / (CAT_ROWS * CAT_ASPECT));
+        int cellW = clamp(Math.min(wFit, hFit), 32, 170);
+        int cellH = Math.max(1, (int) Math.floor(cellW * CAT_ASPECT));
+        int capacity = Math.max(1, cols * CAT_ROWS);
+        int totalPages = entryCount == 0 ? 1 : (entryCount + capacity - 1) / capacity;
+        return new CatalogMetrics(cols, cellW, cellH, capacity, totalPages);
+    }
+
+    /** 目录卡片页网格:一页 ≤10 卡,整块居中,每张卡 = 实时 3D 小人 + 名字条。 */
+    private void renderCatalogGrid(GuiGraphicsExtractor g, int mouseX, int mouseY, List<ModelEntry> entries, int x, int y, int w, int h, float partialTick) {
+        CatalogMetrics m = catalogMetrics(w, h, entries.size());
+        STATE.modelScroll = clamp(STATE.modelScroll, 0, m.totalPages() - 1);
+        int start = STATE.modelScroll * m.capacity();
+        int blockW = m.cols() * m.cellW() + (m.cols() - 1) * CAT_PAD;
+        int blockH = CAT_ROWS * m.cellH() + (CAT_ROWS - 1) * CAT_PAD;
+        int x0 = x + Math.max(CAT_MARGIN, (w - blockW) / 2);
+        int y0 = y + Math.max(CAT_MARGIN, (h - blockH) / 2);
+        Set<String> starred = starModels();
+        Set<String> pageIds = new HashSet<>();
+        outer:
+        for (int row = 0; row < CAT_ROWS; row++) {
+            for (int col = 0; col < m.cols(); col++) {
+                int index = start + row * m.cols() + col;
+                if (index >= entries.size()) {
+                    break outer;
+                }
+                ModelEntry entry = entries.get(index);
+                if (!entry.folder()) {
+                    pageIds.add(entry.modelId());
+                }
+                int cx = x0 + col * (m.cellW() + CAT_PAD);
+                int cy = y0 + row * (m.cellH() + CAT_PAD);
+                renderCatalogCard(g, mouseX, mouseY, entry, cx, cy, m.cellW(), m.cellH(), starred, partialTick);
+            }
+        }
+        evictCardPreviews(pageIds);
+    }
+
+    /** 单张竖卡:实时 3D 小人 / 紫色文件夹卡 / 懒模型加载小圆点。 */
+    private void renderCatalogCard(GuiGraphicsExtractor g, int mouseX, int mouseY, ModelEntry entry, int cx, int cy, int cw, int ch, Set<String> starredModels, float partialTick) {
+        boolean folder = entry.folder();
+        boolean selected = entry.modelId().equals(STATE.selectedModelId) || this.selectedModelIds.contains(entry.modelId());
+        boolean multiSelected = !entry.modelId().equals(STATE.selectedModelId) && this.selectedModelIds.contains(entry.modelId());
+        boolean hover = inside(mouseX, mouseY, cx, cy, cw, ch);
+        boolean starred = !folder && starredModels.contains(entry.modelId());
+        boolean locked = !folder && entry.locked();
+        int nameH = clamp((int) (ch * 0.24f), 20, 46);
+        int coverH = Math.max(1, ch - nameH);
+
+        if (folder) {
+            fill(g, cx, cy, cw, ch, hover ? CAT_FOLDER_HOVER : CAT_FOLDER);
+        } else {
+            fill(g, cx, cy, cw, ch, selected ? CAT_SELECT : hover ? CAT_BASE_HOVER : CAT_BASE);
+        }
+
+        if (folder) {
+            int size = Math.min(34, Math.min(cw - 12, coverH - 12));
+            drawIconScaled(g, IconGlyph.FOLDER, cx + Math.max(0, (cw - size) / 2), cy + Math.max(2, (coverH - size) / 2), size);
+        } else if (!locked) {
+            ModelAssembly asm = residentAssembly(entry.modelId());
+            if (asm == null) {
+                drawCatalogLoading(g, cx, cy, cw, coverH);
+            } else if (asm.isGltf()) {
+                int size = Math.min(30, Math.min(cw - 8, coverH - 10));
+                drawIconScaled(g, IconGlyph.MODEL, cx + Math.max(0, (cw - size) / 2), cy + Math.max(2, (coverH - size) / 2), size);
+            } else {
+                AbstractTexture cover = coverTextureOf(asm);
+                if (cover != null && drawCoverImage(g, cover, cx + 2, cy + 2, cw - 4, coverH - 2)) {
+                    fill(g, cx, cy, cw, coverH, 0x8C000000); // 封面压暗当底,凸显上面的实时小人
+                }
+                renderCatalogCardFigure(g, entry.modelId(), asm, cx, cy, cw, coverH, partialTick);
+            }
+        }
+
+        // 名字条:压在 3D 之后,保证不被小人遮挡
+        fill(g, cx, cy + coverH, cw, nameH, 0xC6000000);
+        drawCatalogName(g, entry, cx, cy + coverH, cw, nameH, folder);
+
+        if (locked) {
+            fill(g, cx, cy, cw, ch, CAT_DIM);
+            drawIcon(g, IconGlyph.LOCK, cx + (cw - 18) / 2, cy + Math.max(2, (coverH - 18) / 2));
+        } else if (!folder) {
+            if (multiSelected) {
+                drawIcon(g, IconGlyph.CHECK, cx + cw - 18, cy + 3);
+            } else if (starred) {
+                drawIcon(g, IconGlyph.STAR, cx + cw - 18, cy + 3);
+            }
+        }
+
+        border(g, cx, cy, cw, ch, selected ? RED : hover ? CAT_STAR_BORDER : 0x55FFFFFF);
+        hit(cx, cy, cw, ch, Component.literal(entry.title()), () -> clickModelEntry(entry));
+    }
+
+    /** 卡片底部名字条。名字够高(≥34)且有条目副标题时排两行,否则单行居中。 */
+    private void drawCatalogName(GuiGraphicsExtractor g, ModelEntry entry, int bx, int by, int cw, int nameH, boolean folder) {
+        int w = Math.max(6, cw - 6);
+        String title = trim(entry.title(), w);
+        String sub = entry.subtitle();
+        boolean twoLine = !folder && nameH >= 34 && sub != null && !sub.isEmpty() && !"folder".equals(sub);
+        int tx = bx + 3;
+        if (twoLine) {
+            g.text(this.font, Component.literal(title), tx, by + 3, CAT_NAME, false);
+            g.text(this.font, Component.literal(trim(sub, w)), tx, by + nameH - this.font.lineHeight - 3, 0xFF9A9A9A, false);
+        } else {
+            g.text(this.font, Component.literal(title), tx, by + Math.max(2, (nameH - this.font.lineHeight) / 2), CAT_NAME, false);
+        }
+    }
+
+    /** 懒模型未常驻:在卡片上部画加载提示小圆点。 */
+    private void drawCatalogLoading(GuiGraphicsExtractor g, int cx, int cy, int cw, int coverH) {
+        int dots = (this.preloadTicker / 3) % 4;
+        String s = "." + ".".repeat(dots);
+        g.text(this.font, Component.literal(s), cx + (cw - this.font.width(s)) / 2, cy + Math.max(6, (coverH - this.font.lineHeight) / 2), CAT_NAME, false);
+    }
+
+    /** 卡片里该模型的实时 3D 小人(与右栏详情同一渲染管线、静止正面;带封面时已垫压暗底)。 */
+    private void renderCatalogCardFigure(GuiGraphicsExtractor g, String modelId, ModelAssembly asm, int cx, int cy, int cw, int coverH, float partialTick) {
+        if (cw < 14 || coverH < 22) {
+            return;
+        }
+        try {
+            String textureId = selectedTextureOrDefault(asm);
+            ClientModelManager.markModelUsed(modelId);
+            PlayerPreviewEntity entity = cardPreviewEntityFor(modelId, textureId);
+            if (entity == null || !entity.isModelReady()) {
+                return;
+            }
+            float scale = clamp(coverH * 0.5f, 16.0f, 170.0f);
+            ModelPreviewRenderer.renderLivingEntityPreview(g, cx, cy, cx + cw, cy + coverH,
+                    cx + cw / 2.0f, cy + coverH - 2.0f, scale, partialTick, entity,
+                    RendererManager.getPlayerRenderer(), true, true);
+        } catch (Exception ignored) {
+            int size = Math.min(26, Math.min(cw - 8, coverH - 10));
+            drawIconScaled(g, IconGlyph.MODEL, cx + Math.max(0, (cw - size) / 2), cy + Math.max(2, (coverH - size) / 2), size);
+        }
+    }
+
+    /** 取/建某模型的卡片预览实体;换贴图时重建。失败返回 null(调用方回退图标)。 */
+    private PlayerPreviewEntity cardPreviewEntityFor(String modelId, String textureId) {
+        PlayerPreviewEntity existing = this.cardPreviewEntities.get(modelId);
+        if (existing != null) {
+            if (!textureId.equals(this.cardPreviewTextureIds.get(modelId))) {
+                try {
+                    existing.initModelWithTexture(modelId, textureId);
+                    this.cardPreviewTextureIds.put(modelId, textureId);
+                } catch (Exception ignored) {
+                }
+            }
+            return existing;
+        }
+        PlayerPreviewEntity created = new PlayerPreviewEntity();
+        try {
+            created.initModelWithTexture(modelId, textureId);
+        } catch (Exception e) {
+            return null;
+        }
+        this.cardPreviewEntities.put(modelId, created);
+        this.cardPreviewTextureIds.put(modelId, textureId);
+        return created;
+    }
+
+    /** 只保留当前页上的卡片预览实体,翻页即释放上一页(防止实体/资源堆积)。 */
+    private void evictCardPreviews(Set<String> keep) {
+        if (this.cardPreviewEntities.size() > keep.size()) {
+            this.cardPreviewEntities.keySet().retainAll(keep);
+            this.cardPreviewTextureIds.keySet().retainAll(keep);
+        }
+    }
+
+    /** 旧式(紧凑/小窗)文字小格,保持原样外观。 */
+    private void renderLegacyCell(GuiGraphicsExtractor g, int mouseX, int mouseY, ModelEntry entry, int cx, int cy, int cw, int ch, int clipTop, int clipBottom, boolean dense, Set<String> starredModels) {
+        boolean selected = entry.modelId().equals(STATE.selectedModelId) || this.selectedModelIds.contains(entry.modelId());
+        int[] hitBox = clampCellToViewport(cx, cy, cw, ch, clipTop, clipBottom);
+        boolean hover = hitBox != null && inside(mouseX, mouseY, hitBox[0], hitBox[1], hitBox[2], hitBox[3]);
+        boolean starred = !entry.folder() && starredModels.contains(entry.modelId());
+        fill(g, cx, cy, cw, ch, selected ? PANEL_ACTIVE : hover ? PANEL_HOVER : 0x3E30363B);
+        border(g, cx, cy, cw, ch, selected ? RED : 0x33FFFFFF);
+        int iconY = dense ? cy + Math.max(0, (ch - 16) / 2) : cy + 3;
+        drawIcon(g, entry.folder() ? IconGlyph.FOLDER : entry.locked() ? IconGlyph.LOCK : IconGlyph.MODEL, cx + 4, iconY);
+        if (dense) {
+            if (starred) {
+                drawIcon(g, IconGlyph.STAR, cx + cw - 18, iconY);
+            }
+            int titleW = starred ? cw - 44 : cw - 26;
+            drawText(g, Component.literal(trim(entry.title(), titleW)), cx + 22, cy + (ch - this.font.lineHeight) / 2 + 1);
+        } else {
+            if (starred) {
+                drawIcon(g, IconGlyph.STAR, cx + cw - 16, cy + ch - 16);
+            }
+            drawText(g, Component.literal(trim(entry.title(), cw - 28)), cx + 22, cy + 6);
+            drawMuted(g, Component.literal(trim(entry.subtitle(), cw - 12)), cx + 6, cy + 22);
+        }
+        if (hitBox != null) {
+            hit(hitBox[0], hitBox[1], hitBox[2], hitBox[3], Component.literal(entry.title()), () -> clickModelEntry(entry));
+        }
+    }
+
+    /** 卡片格:上方封面/占位图,底部压名条。封面=文件夹 ysm 内嵌的 gui_background/gui_foreground。 */
+    private void renderCardCell(GuiGraphicsExtractor g, int mouseX, int mouseY, ModelEntry entry, int cx, int cy, int cw, int ch, int clipTop, int clipBottom, Set<String> starredModels) {
+        boolean selected = entry.modelId().equals(STATE.selectedModelId) || this.selectedModelIds.contains(entry.modelId());
+        boolean multiSelected = !entry.modelId().equals(STATE.selectedModelId) && this.selectedModelIds.contains(entry.modelId());
+        int[] hitBox = clampCellToViewport(cx, cy, cw, ch, clipTop, clipBottom);
+        boolean hover = hitBox != null && inside(mouseX, mouseY, hitBox[0], hitBox[1], hitBox[2], hitBox[3]);
+        boolean starred = !entry.folder() && starredModels.contains(entry.modelId());
+        fill(g, cx, cy, cw, ch, selected ? 0xEF5E7784 : hover ? 0xEF3F4A54 : 0xEF171A1E);
+        int coverH = Math.max(1, ch - NAME_BAND);
+        if (entry.folder()) {
+            int size = Math.min(48, Math.min(cw - 18, coverH - 26));
+            drawIconScaled(g, IconGlyph.FOLDER, cx + Math.max(0, (cw - size) / 2), cy + Math.max(4, (coverH - size) / 2), size);
+        } else {
+            ModelAssembly asm = residentAssembly(entry.modelId());
+            AbstractTexture coverTex = coverTextureOf(asm);
+            boolean coverDrawn = coverTex != null && drawCoverImage(g, coverTex, cx + 2, cy + 2, cw - 4, Math.max(1, coverH - 2));
+            if (!coverDrawn) {
+                int size = Math.min(42, Math.min(cw - 20, coverH - 30));
+                drawIconScaled(g, IconGlyph.MODEL, cx + Math.max(0, (cw - size) / 2), cy + Math.max(4, (coverH - size) / 2), size);
+                if (asm == null && !entry.locked()) {
+                    drawCentered(g, Component.translatable("gui.sparkle_morpher.model_panel.model.on_demand"), cx + cw / 2, cy + coverH - 13, MUTED);
+                }
+            }
+        }
+        if (entry.locked()) {
+            fill(g, cx + 1, cy + 1, cw - 2, coverH - 2, 0x99000000);
+            drawIcon(g, IconGlyph.LOCK, cx + (cw - 18) / 2, cy + Math.max(2, (coverH - 18) / 2));
+        }
+        if (multiSelected) {
+            drawIcon(g, IconGlyph.CHECK, cx + cw - 19, cy + 3);
+        } else if (starred) {
+            drawIcon(g, IconGlyph.STAR, cx + cw - 19, cy + 3);
+        }
+        int bandY = cy + coverH;
+        if (ch > NAME_BAND) {
+            fill(g, cx + 1, bandY, cw - 2, ch - coverH - 1, 0xB0000000);
+        }
+        drawText(g, Component.literal(trim(entry.title(), Math.max(8, cw - 10))), cx + 5, bandY + 3);
+        if (!entry.folder() && NAME_BAND >= 29) {
+            String sub = entry.subtitle();
+            if (sub != null && !sub.isEmpty()) {
+                drawMuted(g, Component.literal(trim(sub, Math.max(8, cw - 10))), cx + 5, bandY + 14);
+            }
+        }
+        border(g, cx, cy, cw, ch, selected ? RED : hover ? 0x99FFFFFF : 0x374D5A66);
+        if (hitBox != null) {
+            hit(hitBox[0], hitBox[1], hitBox[2], hitBox[3], Component.literal(entry.title()), () -> clickModelEntry(entry));
+        }
+    }
+
+    /** 把格子点击/悬停区夹到网格视口内,避免像素滚动时半可见首/末行把可点区伸出面板外。返回 null 表示完全不可见。 */
+    private static int[] clampCellToViewport(int cx, int cy, int cw, int ch, int clipTop, int clipBottom) {
+        int top = Math.max(cy, clipTop);
+        int bottom = Math.min(cy + ch, clipBottom);
+        if (bottom <= top) {
+            return null;
+        }
+        return new int[]{cx, top, cw, bottom - top};
     }
 
     private ModelListMetrics modelListMetrics(int w, int h, int entryCount) {
         boolean dense = compactModelLayout() || h < 132;
-        int targetW = dense ? 104 : 116;
-        int minW = dense ? 86 : 92;
-        int maxW = dense ? 132 : 150;
-        int cellW = Math.max(minW, Math.min(maxW, w / Math.max(1, w / targetW)));
-        int cols = Math.max(1, w / cellW);
-        int cellH = dense ? DENSE_MODEL_ROW : h < 90 ? 42 : 50;
-        int rows = Math.max(1, h / cellH);
-        int maxScroll = Math.max(0, (entryCount + cols - 1) / cols - rows);
-        return new ModelListMetrics(cellW, cellH, cols, rows, maxScroll, dense);
+        boolean cards = false; // 目录卡片页由 renderCatalogGrid 独占;此处恒为文字行格
+        int cellW;
+        int cellH;
+        int cols;
+        if (cards) {
+            int targetCols = Math.max(1, w / CARD_TARGET_W);
+            cellW = clamp(w / targetCols, CARD_MIN_CELL_W, CARD_MAX_W);
+            cols = Math.max(1, w / cellW);
+            cellH = Math.max(CARD_MIN_H - 12, Math.min(CARD_MAX_CELL_H, cellW + 26));
+        } else {
+            int targetW = dense ? 104 : 116;
+            int minW = dense ? 86 : 92;
+            int maxW = dense ? 132 : 150;
+            cellW = Math.max(minW, Math.min(maxW, w / Math.max(1, w / targetW)));
+            cols = Math.max(1, w / cellW);
+            cellH = dense ? DENSE_MODEL_ROW : h < 90 ? 42 : 50;
+        }
+        int contentRows = entryCount == 0 ? 0 : (entryCount + cols - 1) / cols;
+        int maxScroll = Math.max(0, contentRows * cellH - h);
+        return new ModelListMetrics(cellW, cellH, cols, contentRows, maxScroll, dense, cards);
     }
 
     private List<ModelEntry> visibleModelEntries() {
         List<ModelEntry> entries = collectModelEntries();
+        if (entries.isEmpty()) {
+            return List.of();
+        }
+        if (modelCardsActive()) {
+            CatalogMetrics m = catalogMetrics(modelListW(), currentModelGridH(), entries.size());
+            int page = clamp(STATE.modelScroll, 0, m.totalPages() - 1);
+            int start = page * m.capacity();
+            int end = Math.min(entries.size(), start + m.capacity());
+            return start >= end ? List.of() : entries.subList(start, end);
+        }
         ModelListMetrics metrics = modelListMetrics(modelListW(), currentModelGridH(), entries.size());
         STATE.modelScroll = clamp(STATE.modelScroll, 0, metrics.maxScroll());
-        int start = STATE.modelScroll * metrics.cols();
-        int end = Math.min(entries.size(), start + metrics.rows() * metrics.cols());
-        return start >= end ? List.of() : entries.subList(start, end);
+        int[] range = visibleIndexRange(metrics, entries.size());
+        return range[1] <= range[0] ? List.of() : entries.subList(range[0], range[1]);
+    }
+
+    /** 当前滚动下至少部分可见的条目下标区间 [first, endExclusive)。 */
+    private int[] visibleIndexRange(ModelListMetrics metrics, int count) {
+        if (count == 0 || metrics.cellH() <= 0) {
+            return new int[]{0, 0};
+        }
+        int cols = metrics.cols();
+        int contentRows = metrics.contentRows();
+        int startRow = clamp(STATE.modelScroll / metrics.cellH(), 0, Math.max(0, contentRows - 1));
+        int viewportH = currentModelGridH();
+        int rowsVisible = Math.max(1, (viewportH + metrics.cellH() - 1) / metrics.cellH());
+        int first = startRow * cols;
+        int last = Math.min(count, first + rowsVisible * cols);
+        return new int[]{first, last};
+    }
+
+    /** 模型网格每格滚轮滚动像素量;卡片较高时限制步长避免跳太快。 */
+    private int modelWheelStep() {
+        int cellH = DENSE_MODEL_ROW;
+        if (this.layout != null) {
+            List<ModelEntry> entries = collectModelEntries();
+            if (!entries.isEmpty()) {
+                ModelListMetrics metrics = modelListMetrics(modelListW(), currentModelGridH(), entries.size());
+                cellH = metrics.cellH();
+            }
+        }
+        return Math.max(8, Math.min(WHEEL_STEP_MAX, cellH));
+    }
+
+    /** 常驻(运行时已解析)assembly;懒/占位 assembly 返回 null。 */
+    private ModelAssembly residentAssembly(String modelId) {
+        if (modelId == null) {
+            return null;
+        }
+        ModelAssembly asm = ClientModelManager.getModelAssemblyMap().get(modelId);
+        return asm != null && asm.isRuntimeResident() ? asm : null;
+    }
+
+    /** 文件夹 ysm 内嵌 GUI 封面:优先 gui_background,缺则退回 gui_foreground。 */
+    private AbstractTexture coverTextureOf(ModelAssembly asm) {
+        if (asm == null) {
+            return null;
+        }
+        ModelDisplayAssets assets = asm.getTextureRegistry();
+        if (assets == null) {
+            return null;
+        }
+        AbstractTexture background = assets.getGuiBackground();
+        return background != null ? background : assets.getGuiForeground();
+    }
+
+    /** 把封面等比 fit 进 (x,y,w,h),居中不拉伸。无法获得资源/尺寸时返回 false。 */
+    private boolean drawCoverImage(GuiGraphicsExtractor g, AbstractTexture tex, int x, int y, int w, int h) {
+        if (tex == null || w <= 0 || h <= 0) {
+            return false;
+        }
+        int[] dims = coverDimensions(tex);
+        if (dims == null) {
+            return false;
+        }
+        IResourceLocatable locatable = UploadManager.getOrCreateLocatable(tex, true);
+        if (locatable == null) {
+            return false;
+        }
+        Identifier loc = locatable.getResourceLocationOrNull();
+        if (loc == null) {
+            return false;
+        }
+        int texW = dims[0];
+        int texH = dims[1];
+        double scale = Math.min((double) w / texW, (double) h / texH);
+        int dw = Math.max(1, (int) Math.floor(texW * scale));
+        int dh = Math.max(1, (int) Math.floor(texH * scale));
+        int x0 = x + (w - dw) / 2;
+        int y0 = y + (h - dh) / 2;
+        g.blit(loc, x0, y0, x0 + dw, y0 + dh, 0.0f, 1.0f, 0.0f, 1.0f);
+        return true;
+    }
+
+    /** 封面尺寸(像素)。gui 图一定是 OuterFileTexture(构建链 toPng),直接读 PNG IHDR。 */
+    private int[] coverDimensions(AbstractTexture tex) {
+        if (!(tex instanceof OuterFileTexture outer)) {
+            return null;
+        }
+        synchronized (COVER_DIMS) {
+            int[] dims = COVER_DIMS.get(tex);
+            if (dims == null) {
+                dims = pngHeaderSize(outer.getResourceData());
+                if (dims != null) {
+                    COVER_DIMS.put(tex, dims);
+                }
+            }
+            return dims;
+        }
+    }
+
+    private static int[] pngHeaderSize(byte[] data) {
+        if (data == null || data.length < 24) {
+            return null;
+        }
+        // PNG 签名 8 字节 + IHDR 块(length 4 + "IHDR" 4),宽高自偏移 16 起大端。
+        if ((data[0] & 0xFF) != 0x89 || data[1] != 0x50 || data[2] != 0x4E || data[3] != 0x47) {
+            return null;
+        }
+        int w = readIntBE(data, 16);
+        int h = readIntBE(data, 20);
+        return w > 0 && h > 0 && w <= 16384 && h <= 16384 ? new int[]{w, h} : null;
+    }
+
+    private static int readIntBE(byte[] data, int offset) {
+        return ((data[offset] & 0xFF) << 24) | ((data[offset + 1] & 0xFF) << 16) | ((data[offset + 2] & 0xFF) << 8) | (data[offset + 3] & 0xFF);
+    }
+
+    /** 图标纹理按 size 等比放大绘制(源是 16px 格)。 */
+    private void drawIconScaled(GuiGraphicsExtractor g, IconGlyph icon, int x, int y, int size) {
+        if (size <= 0) {
+            return;
+        }
+        g.blit(MODEL_PANEL_ICONS, x, y, x + size, y + size, icon.u / 128.0f, (icon.u + 16) / 128.0f, icon.v / 64.0f, (icon.v + 16) / 64.0f);
     }
 
     private int currentModelGridH() {
@@ -680,22 +1151,107 @@ public class ModernPlayerModelScreen extends Screen {
         if (entries.isEmpty()) {
             return;
         }
+        if (fitsCatalog(w, gridH)) {
+            renderCatalogPageControls(g, mouseX, mouseY, entries, x, y, w, gridH);
+            return;
+        }
         ModelListMetrics metrics = modelListMetrics(w, gridH, entries.size());
         STATE.modelScroll = clamp(STATE.modelScroll, 0, metrics.maxScroll());
-        int visible = metrics.rows() * metrics.cols();
-        int start = Math.min(entries.size(), STATE.modelScroll * metrics.cols());
-        int end = Math.min(entries.size(), start + visible);
-        Component range = Component.literal((start + 1) + "-" + end + "/" + entries.size());
+        int[] range = visibleIndexRange(metrics, entries.size());
+        int start = range[0];
+        int end = Math.min(entries.size(), range[1]);
+        Component countRange = Component.literal((start + 1) + "-" + end + "/" + entries.size());
         int nextX = x + w - MODEL_PAGE_BUTTON_WIDTH - 6;
         int prevX = nextX - MODEL_PAGE_BUTTON_WIDTH - 4;
-        int labelX = Math.max(x + 82, prevX - this.font.width(range) - 8);
-        drawMuted(g, range, labelX, y + 8);
+        int labelX = Math.max(x + 82, prevX - this.font.width(countRange) - 8);
+        drawMuted(g, countRange, labelX, y + 8);
+        int pageStep = Math.max(1, gridH - metrics.cellH() / 2);
         renderTextButton(g, mouseX, mouseY, prevX, y + 3, MODEL_PAGE_BUTTON_WIDTH, MODEL_PAGE_BUTTON_HEIGHT, Component.translatable("gui.sparkle_morpher.pre_page"), () -> {
-            STATE.modelScroll = Math.max(0, STATE.modelScroll - metrics.rows());
+            STATE.modelScroll = Math.max(0, STATE.modelScroll - pageStep);
         });
         renderTextButton(g, mouseX, mouseY, nextX, y + 3, MODEL_PAGE_BUTTON_WIDTH, MODEL_PAGE_BUTTON_HEIGHT, Component.translatable("gui.sparkle_morpher.next_page"), () -> {
-            STATE.modelScroll = Math.min(metrics.maxScroll(), STATE.modelScroll + metrics.rows());
+            STATE.modelScroll = Math.min(metrics.maxScroll(), STATE.modelScroll + pageStep);
         });
+    }
+
+    /** 目录卡片页翻页控件:STATE.modelScroll 此时即页号,整页前进/后退。 */
+    private void renderCatalogPageControls(GuiGraphicsExtractor g, int mouseX, int mouseY, List<ModelEntry> entries, int x, int y, int w, int gridH) {
+        CatalogMetrics m = catalogMetrics(w, gridH, entries.size());
+        int page = clamp(STATE.modelScroll, 0, m.totalPages() - 1);
+        STATE.modelScroll = page;
+        int start = page * m.capacity();
+        int end = Math.min(entries.size(), start + m.capacity());
+        Component countRange = Component.literal((start + 1) + "-" + end + "/" + entries.size());
+        int nextX = x + w - MODEL_PAGE_BUTTON_WIDTH - 6;
+        int prevX = nextX - MODEL_PAGE_BUTTON_WIDTH - 4;
+        int labelX = Math.max(x + 82, prevX - this.font.width(countRange) - 8);
+        drawMuted(g, countRange, labelX, y + 8);
+        renderTextButton(g, mouseX, mouseY, prevX, y + 3, MODEL_PAGE_BUTTON_WIDTH, MODEL_PAGE_BUTTON_HEIGHT, Component.translatable("gui.sparkle_morpher.pre_page"), () -> {
+            if (page > 0) {
+                STATE.modelScroll = page - 1;
+            }
+        });
+        renderTextButton(g, mouseX, mouseY, nextX, y + 3, MODEL_PAGE_BUTTON_WIDTH, MODEL_PAGE_BUTTON_HEIGHT, Component.translatable("gui.sparkle_morpher.next_page"), () -> {
+            if (page < m.totalPages() - 1) {
+                STATE.modelScroll = page + 1;
+            }
+        });
+    }
+
+    /**
+     * 目录页懒模型自动预载:后台把「当前页 + 下一页」的未常驻模型逐个载入常驻,
+     * 落地后卡片小人/封面随后续渲染自然出现。只对目录页生效(文字行格不做预载)。
+     */
+    private void preloadVisibleCovers() {
+        if (STATE.activeTab != ModelPanelState.Tab.MODEL
+                || STATE.secondaryPanel != ModelPanelState.SecondaryPanel.NONE
+                || this.layout == null
+                || !modelCardsActive()) {
+            return;
+        }
+        List<ModelEntry> entries = collectModelEntries();
+        if (entries.isEmpty()) {
+            return;
+        }
+        CatalogMetrics m = catalogMetrics(modelListW(), currentModelGridH(), entries.size());
+        STATE.modelScroll = clamp(STATE.modelScroll, 0, m.totalPages() - 1);
+        int budget = PRELOAD_BUDGET;
+        for (int p = 0; p < 2 && budget > 0; p++) {
+            int page = clamp(STATE.modelScroll + p, 0, m.totalPages() - 1);
+            int start = page * m.capacity();
+            int end = Math.min(entries.size(), start + m.capacity());
+            for (int i = start; i < end && budget > 0; i++) {
+                ModelEntry entry = entries.get(i);
+                if (entry.folder()) {
+                    continue;
+                }
+                String id = entry.modelId();
+                if (residentAssembly(id) != null) {
+                    this.preloadFailed.remove(id);
+                    this.preloadWatching.remove(id);
+                    this.preloadWatchStart.remove(id);
+                    continue;
+                }
+                if (this.preloadFailed.contains(id)) {
+                    continue;
+                }
+                if (this.preloadWatching.contains(id)) {
+                    Integer started = this.preloadWatchStart.get(id);
+                    if (started != null && this.preloadTicker - started >= PRELOAD_GIVE_UP_TICKS
+                            && !ClientModelManager.isModelLoadPending(id)) {
+                        // 长时间未落地且不再有加载任务:判为失败,本屏幕内不再尝试。
+                        this.preloadWatching.remove(id);
+                        this.preloadWatchStart.remove(id);
+                        this.preloadFailed.add(id);
+                    }
+                    continue;
+                }
+                this.preloadWatching.add(id);
+                this.preloadWatchStart.put(id, this.preloadTicker);
+                budget--;
+                ClientModelManager.getModelContext(id);
+            }
+        }
     }
 
     private void renderModelDetails(GuiGraphicsExtractor g, int mouseX, int mouseY, int x, int y, int w, int h, float partialTick) {
@@ -1171,7 +1727,15 @@ public class ModernPlayerModelScreen extends Screen {
             return true;
         }
         switch (STATE.activeTab) {
-            case MODEL -> STATE.modelScroll = Math.max(0, STATE.modelScroll + delta);
+            case MODEL -> {
+                if (modelCardsActive()) {
+                    List<ModelEntry> pageEntries = collectModelEntries();
+                    int pages = pageEntries.isEmpty() ? 1 : catalogMetrics(modelListW(), currentModelGridH(), pageEntries.size()).totalPages();
+                    STATE.modelScroll = clamp(STATE.modelScroll + delta, 0, pages - 1);
+                } else {
+                    STATE.modelScroll = Math.max(0, STATE.modelScroll + delta * modelWheelStep());
+                }
+            }
             case RESOURCE -> STATE.resourceScroll = Math.max(0, STATE.resourceScroll + delta);
             case SETTINGS -> STATE.settingsScroll = Math.max(0, STATE.settingsScroll + delta);
         }
@@ -2367,7 +2931,10 @@ public class ModernPlayerModelScreen extends Screen {
     private record Hit(int x, int y, int w, int h, Component tooltip, Runnable action) {
     }
 
-    private record ModelListMetrics(int cellW, int cellH, int cols, int rows, int maxScroll, boolean dense) {
+    private record ModelListMetrics(int cellW, int cellH, int cols, int contentRows, int maxScroll, boolean dense, boolean cards) {
+    }
+
+    private record CatalogMetrics(int cols, int cellW, int cellH, int capacity, int totalPages) {
     }
 
     private record ModelEntry(String modelId, String title, String subtitle, boolean folder, boolean locked) {

--- a/fabric/src/main/java/com/micaftic/morpher/client/gui/ModernPlayerModelScreen.java
+++ b/fabric/src/main/java/com/micaftic/morpher/client/gui/ModernPlayerModelScreen.java
@@ -60,6 +60,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
@@ -159,6 +160,14 @@ public class ModernPlayerModelScreen extends Screen {
     private final Set<String> preloadWatching = new HashSet<>();
     private final Map<String, Integer> preloadWatchStart = new LinkedHashMap<>();
     private int preloadTicker;
+
+    // 模型网格“稳定排序”:指纹不变(集合/路径/筛选/搜索/星标未变)时复用上一次的排序结果。
+    // 后台预载把模型从“目录项”变成“常驻”时,其名字来源会从懒加载的嗅探名/路径升级为真名;
+    // 若每帧按名字重排,整排卡片就会在加载完成瞬间来回乱跳。指纹只跟“有哪些模型”绑定、与名字无关,
+    // 所以加载期名字刷新只会原位更新卡片文字,不会让卡片挪动位置。
+    private String modelListFingerprint = "";
+    private List<String> modelListOrder = List.of();
+
 
     private enum IconGlyph {
         MODEL(0, 0),
@@ -1790,7 +1799,7 @@ public class ModernPlayerModelScreen extends Screen {
                 continue;
             }
             boolean locked = assembly.getTextureRegistry().isAuthModel() && !auth.contains(modelId);
-            out.add(ModelEntry.model(modelId, displayName(modelId, assembly), modelSubtitle(modelId, assembly), locked));
+            out.add(ModelEntry.model(modelId, listTitle(modelId, assembly), modelSubtitle(modelId, assembly), locked));
         }
         for (String modelId : ClientModelManager.getAvailableModelIds()) {
             if (ClientModelManager.getModelAssemblyMap().containsKey(modelId)) continue;
@@ -1808,11 +1817,76 @@ public class ModernPlayerModelScreen extends Screen {
             out.add(ModelEntry.model(modelId, lazyTitle,
                     Component.translatable("gui.sparkle_morpher.model_panel.model.on_demand").getString(), locked));
         }
-        out.sort(Comparator
-                .<ModelEntry, Boolean>comparing(e -> !stars.contains(e.modelId()))
-                .thenComparing(Comparator.<ModelEntry, Boolean>comparing(entry -> entry.folder()).reversed())
-                .thenComparing(e -> e.title().toLowerCase(Locale.ROOT)));
-        return out;
+        return applyStableModelOrder(out, stars);
+    }
+
+    /**
+     * 模型条目的稳定排序键:文件夹与模型分开记名,避免同名字符串被两种条目同时占用。
+     */
+    private static String modelEntryOrderKey(ModelEntry entry) {
+        return (entry.folder() ? "F/" : "M/") + entry.modelId();
+    }
+
+    /**
+     * 排序指纹:只依赖“当前模型集合 + 浏览上下文”,与条目名字/常驻加载状态无关。
+     * 集合/路径/筛选/搜索/星标任一变化 → 指纹变化 → 重新全量排序;否则复用上一次排序。
+     */
+    private String modelListFingerprintOf(List<ModelEntry> entries, Set<String> stars) {
+        StringBuilder sb = new StringBuilder(96 + entries.size() * 24);
+        sb.append(STATE.currentPath).append('\0');
+        sb.append(STATE.modelFilter).append('\0');
+        sb.append(STATE.modelSearchText.trim()).append('\0');
+        List<String> keys = new ArrayList<>(entries.size());
+        for (ModelEntry entry : entries) {
+            String key = modelEntryOrderKey(entry);
+            if (!entry.folder() && stars.contains(entry.modelId())) {
+                key = "*" + key; // 星标集合也参与指纹:列表内点星/取消后需要重排
+            }
+            keys.add(key);
+        }
+        keys.sort(String::compareTo);
+        for (String key : keys) {
+            sb.append(key).append('\1');
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 集合未变时复用上次的稳定顺序,只为仍存在的条目刷新文字(title/subtitle/locked),
+     * 新出现的条目(指纹变化必走全量重建,此分支仅作兜底)按当前顺序追加到末尾。
+     */
+    private List<ModelEntry> applyStableModelOrder(List<ModelEntry> unsorted, Set<String> stars) {
+        String fingerprint = modelListFingerprintOf(unsorted, stars);
+        if (fingerprint.equals(this.modelListFingerprint) && !this.modelListOrder.isEmpty()) {
+            Map<String, ModelEntry> byKey = new HashMap<>(Math.max(16, unsorted.size() * 2));
+            for (ModelEntry entry : unsorted) {
+                byKey.put(modelEntryOrderKey(entry), entry);
+            }
+            List<ModelEntry> ordered = new ArrayList<>(unsorted.size());
+            for (String key : this.modelListOrder) {
+                ModelEntry entry = byKey.remove(key);
+                if (entry != null) {
+                    ordered.add(entry);
+                }
+            }
+            for (ModelEntry entry : unsorted) {
+                if (byKey.containsKey(modelEntryOrderKey(entry))) {
+                    ordered.add(entry);
+                }
+            }
+            return ordered;
+        }
+        List<ModelEntry> sorted = new ArrayList<>(unsorted);
+        sorted.sort(Comparator
+                .<ModelEntry, Boolean>comparing(entry -> !stars.contains(entry.modelId()))
+                .thenComparing(Comparator.<ModelEntry, Boolean>comparing(ModelEntry::folder).reversed())
+                .thenComparing(entry -> entry.title().toLowerCase(Locale.ROOT)));
+        this.modelListFingerprint = fingerprint;
+        this.modelListOrder = new ArrayList<>(sorted.size());
+        for (ModelEntry entry : sorted) {
+            this.modelListOrder.add(modelEntryOrderKey(entry));
+        }
+        return sorted;
     }
 
     private boolean matchesModelFilter(String modelId, ModelAssembly assembly, Set<String> auth, Set<String> stars) {
@@ -2486,6 +2560,24 @@ public class ModernPlayerModelScreen extends Screen {
 
     private boolean isMainlandResourceMode() {
         return this.resourceConfig.mainlandChinaMode();
+    }
+
+    /**
+     * 卡片名字的单一来源:真正常驻(有运行态几何/表达式缓存)的模型显示实时本地化名;
+     * 尚未真正加载的(LazyModelAssembly 占位 / 纯目录项)用目录缓存名——嗅探到的 metadata 名
+     * 或服务器解析后写回 source.displayName 的真名,都没有才退回 modelId。
+     *
+     * <p>这样同一模型在“目录项→常驻”两个状态下名字不各算一套:占位被真正模型替换时,
+     * 卡片只是原位把名字升级成真名,不会因为换了一套名字源而被重新排序乱跳。</p>
+     */
+    private String listTitle(String modelId, ModelAssembly assembly) {
+        if (assembly != null && assembly.isRuntimeResident()) {
+            String live = displayName(modelId, assembly);
+            if (!modelId.equals(live)) {
+                return live;
+            }
+        }
+        return lazyModelDisplayName(modelId);
     }
 
     private String displayName(String modelId, ModelAssembly assembly) {

--- a/fabric/src/main/java/com/micaftic/morpher/client/gui/YsmCardAnimator.java
+++ b/fabric/src/main/java/com/micaftic/morpher/client/gui/YsmCardAnimator.java
@@ -1,0 +1,87 @@
+package com.micaftic.morpher.client.gui;
+
+import com.micaftic.morpher.client.entity.PlayerPreviewEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+final class YsmCardAnimator {
+
+    private static final long FADEOUT_MILLIS = 350L;
+
+    private final Map<String, String> defaultAnimByModel = new HashMap<>();
+    private final Map<String, Long> hoverSince = new HashMap<>();
+    private final Map<String, Long> fadeoutUntil = new HashMap<>();
+
+    private static boolean hasAnim(PlayerPreviewEntity entity, String name) {
+        if (entity == null || name == null) {
+            return false;
+        }
+        try {
+            return entity.getAnimation(name) != null;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private String defaultAnim(String modelId, PlayerPreviewEntity entity) {
+        String cached = this.defaultAnimByModel.get(modelId);
+        if (cached != null) {
+            return cached.isEmpty() ? null : cached;
+        }
+        String resolved = "";
+        try {
+            var props = entity.getModelAssembly().getModelData().getModelProperties();
+            String declared = props == null ? null : props.getPreviewAnimation();
+            if (declared != null && !declared.isEmpty() && hasAnim(entity, declared)) {
+                resolved = declared;
+            } else if (hasAnim(entity, "idle")) {
+                resolved = "idle";
+            }
+        } catch (Exception ignored) {
+        }
+        this.defaultAnimByModel.put(modelId, resolved);
+        return resolved.isEmpty() ? null : resolved;
+    }
+
+    void forget(String modelId) {
+        this.defaultAnimByModel.remove(modelId);
+        this.hoverSince.remove(modelId);
+        this.fadeoutUntil.remove(modelId);
+    }
+
+    void update(String modelId, PlayerPreviewEntity entity, boolean hover, long now) {
+        if (entity == null) {
+            return;
+        }
+        try {
+            String idle = defaultAnim(modelId, entity);
+            boolean hasHover = hasAnim(entity, "hover");
+            boolean hasFade = hasAnim(entity, "hover_fadeout");
+            if (hover) {
+                this.hoverSince.put(modelId, now);
+                this.fadeoutUntil.remove(modelId);
+            } else if (this.hoverSince.containsKey(modelId)) {
+                this.hoverSince.remove(modelId);
+                if (hasFade) {
+                    this.fadeoutUntil.put(modelId, now + FADEOUT_MILLIS);
+                }
+            }
+            Long until = this.fadeoutUntil.get(modelId);
+            boolean fading = until != null && now < until;
+
+            entity.getAnimationStateMachine().setCurrentAnimation(idle == null ? "" : idle);
+            if (hover) {
+                entity.getAnimationStateMachine().setPreviousAnimation(hasHover ? "hover" : "");
+            } else if (fading) {
+                entity.getAnimationStateMachine().setPreviousAnimation(hasFade ? "hover_fadeout" : "");
+            } else {
+                if (until != null) {
+                    this.fadeoutUntil.remove(modelId);
+                }
+                entity.getAnimationStateMachine().setPreviousAnimation("");
+            }
+        } catch (Exception ignored) {
+        }
+    }
+}


### PR DESCRIPTION
**背景**:把 26.x 分支上已合并的 Faithful 3D 目录卡片网格(与上游一致的 52×90 实时 3D 预览卡、紫色文件夹卡、Prev/Next 翻页)移植到 fa26.1.2。

**改动**(仅 ModernPlayerModelScreen.java,与 26.x 各线同一实现):
- 目录卡片模式:catalog 卡片网格 5列×2行/页,每卡实时 3D PlayerPreviewEntity 小人、底部压模型名、文件夹紫色卡。
- 视口足够大(CAT_MIN_W/CAT_MIN_H)时启用目录卡;窄窗/紧凑布局保持原文字小格,不退化。
- 按页分页滚动,卡片预览随页按需创建/驱逐。
- 懒模型封面随当前/下一页预载。
